### PR TITLE
Adding color to the --compare command

### DIFF
--- a/ERC/ERC/Display_Output.cs
+++ b/ERC/ERC/Display_Output.cs
@@ -1133,6 +1133,7 @@ namespace ERC
         {
             List<string> output = new List<string>();
             byte[] memoryRegion = new byte[byteArray.Length];
+            List<byte> mismatchingBytes = new List<byte>();
             int bytesRead = 0;
             output.Add("                   ----------------------------------------------------");
             string fromArray  = "        From Array | ";
@@ -1167,18 +1168,34 @@ namespace ERC
                         fromArray = "        From Array | ";
                         fromRegion = "From Memory Region | ";
                     }
+
                     byte[] thisByte = new byte[1];
                     thisByte[0] = byteArray[i];
-                    fromArray += BitConverter.ToString(thisByte);
-                    fromArray += " ";
+                    if (byteArray[i] != memoryRegion[i])
+                    {
+                        mismatchingBytes.Add(byteArray[i]);
+                        fromArray += "[color@red]" + BitConverter.ToString(thisByte) + "[stopcolor]";
+                        thisByte[0] = memoryRegion[i];
+                        fromRegion += "[color@red]" + BitConverter.ToString(thisByte) + "[stopcolor]";
+                    }
+                    else
+                    {
+                        fromArray += BitConverter.ToString(thisByte);
+                        thisByte[0] = memoryRegion[i];
+                        fromRegion += BitConverter.ToString(thisByte);
+                    }
 
-                    thisByte[0] = memoryRegion[i];
-                    fromRegion += BitConverter.ToString(thisByte);
+                    fromArray += " ";
                     fromRegion += " ";
                     counter++;
                 }
             }
             output.Add("                   ----------------------------------------------------");
+            output.Add("Mismatching Bytes: [" + String.Join(", ", mismatchingBytes.Select(b => BitConverter.ToString(new byte[]{b}))) + "]");
+            if(mismatchingBytes.Count > 0)
+            {
+                output.Add("Remove byte 0x" + BitConverter.ToString(new byte[] { mismatchingBytes.ElementAt(0) }) + " and attempt again.");
+            }
             return output.ToArray();
         }
         #endregion


### PR DESCRIPTION
Adding color to the --compare command to highlight mismatching bytes, as well as keeping record of all the mismatching bytes and displaying back to user.

![2022-02-12-18_08-3crN6DNOLJ](https://user-images.githubusercontent.com/1904543/153702295-55e1bd9a-b8a8-4e17-a1dd-365378de7670.png)

Requires the following PR to be merged into x64dbg first: https://github.com/x64dbg/x64dbg/pull/2834. Labeled as draft PR.