### PR TITLE
Update colouring for --compare command to HTML

### DIFF
--- a/DllExport.bat
+++ b/DllExport.bat
@@ -1,0 +1,509 @@
+@echo off
+:: Copyright (c) 2016-2021  Denis Kuzmin [x-3F@outlook.com] github/3F
+:: https://github.com/3F/DllExport
+if "%~1"=="/?" goto bq
+set "aa=%~dpnx0"
+set ab=%*
+set ac=%*
+if defined ab (
+if defined __p_call (
+set ac=%ac:^^=^%
+) else (
+set ab=%ab:^=^^%
+)
+)
+set wMgrArgs=%ac%
+set ad=%ab:!=^!%
+setlocal enableDelayedExpansion
+set "ae=^"
+set "ad=!ad:%%=%%%%!"
+set "ad=!ad:&=%%ae%%&!"
+set "af=1.7.4"
+set "wAction=Configure"
+set "ag=DllExport"
+set "ah=tools/net.r_eg.DllExport.Wizard.targets"
+set "ai=packages"
+set "aj=https://www.nuget.org/api/v2/package/"
+set "ak=build_info.txt"
+set "al=!aa!"
+set "wRootPath=!cd!"
+set /a wDxpOpt=0
+set "am="
+set "an="
+set "ao="
+set "ap="
+set "aq="
+set "ar="
+set "as="
+set "at="
+set "au="
+set "av="
+set /a aw=0
+if not defined ab (
+if defined wAction goto br
+goto bq
+)
+call :bs bk !ad! bl
+goto bt
+:bq
+echo.
+@echo .NET DllExport v1.7.4.29858+c1cc52f
+@echo Copyright (c) 2009-2015  Robert Giesecke
+@echo Copyright (c) 2016-2021  Denis Kuzmin ^<x-3F@outlook.com^> github/3F
+echo.
+echo MIT License
+@echo https://github.com/3F/DllExport
+echo Based on hMSBuild, MvsSln, +GetNuTool: https://github.com/3F
+echo.
+@echo.
+@echo Usage: DllExport [args to DllExport] [args to GetNuTool] [args to hMSBuild]
+echo ------
+echo.
+echo Arguments
+echo ---------
+echo -action {type} - Specified action for Wizard. Where {type}:
+echo   * Configure - To configure DllExport for specific projects.
+echo   * Update    - To update pkg reference for already configured projects.
+echo   * Restore   - To restore configured DllExport.
+echo   * Export    - To export configured projects data.
+echo   * Recover   - To re-configure projects via predefined/exported data.
+echo   * Unset     - To unset all data from specified projects.
+echo   * Upgrade   - Aggregates an Update action with additions for upgrading.
+echo.
+echo -sln-dir {path}    - Path to directory with .sln files to be processed.
+echo -sln-file {path}   - Optional predefined .sln file to be processed.
+echo -metalib {path}    - Relative path to meta library.
+echo -metacor {path}    - Relative path to meta core library.
+echo -dxp-target {path} - Relative path to entrypoint wrapper of the main core.
+echo -dxp-version {num} - Specific version of DllExport. Where {num}:
+echo   * Versions: 1.7.3 ...
+echo   * Keywords:
+echo     `actual` - Unspecified local/latest remote version;
+echo                ( Only if you know what you are doing )
+echo.
+echo -msb {path}           - Full path to specific msbuild.
+echo -hMSBuild {args}      - Access to hMSBuild tool (packed) https://github.com/3F/hMSBuild
+echo -packages {path}      - A common directory for packages.
+echo -server {url}         - Url for searching remote packages.
+echo -proxy {cfg}          - To use proxy. The format: [usr[:pwd]@]host[:port]
+echo -pkg-link {uri}       - Direct link to package from the source via specified URI.
+echo -force                - Aggressive behavior, e.g. like removing pkg when updating.
+echo -no-mgr               - Do not use %~nx0 for automatic restore the remote package.
+echo -mgr-up               - Updates %~nx0 to version from '-dxp-version'.
+echo -wz-target {path}     - Relative path to entrypoint wrapper of the main wizard.
+echo -pe-exp-list {module} - To list all available exports from PE32/PE32+ module.
+echo -eng                  - Try to use english language for all build messages.
+echo -GetNuTool {args}     - Access to GetNuTool (integrated) https://github.com/3F/GetNuTool
+echo -debug                - To show additional information.
+echo -version              - Displays version for which (together with) it was compiled.
+echo -build-info           - Displays actual build information from selected DllExport.
+echo -help                 - Displays this help. Aliases: -help -h
+echo.
+echo Flags
+echo -----
+echo  __p_call - To use the call-type logic when invoking %~nx0
+echo.
+echo Samples
+echo -------
+echo DllExport -action Configure -force -pkg-link http://host/v1.7.3.nupkg
+echo DllExport -action Restore -sln-file "Conari.sln"
+echo DllExport -proxy guest:1234@10.0.2.15:7428 -action Configure
+echo.
+echo DllExport -mgr-up -dxp-version 1.7.3
+echo DllExport -action Upgrade -dxp-version 1.7.3
+echo.
+echo DllExport -GetNuTool /p:ngpackages="Conari;regXwild"
+echo DllExport -pe-exp-list bin\Debug\regXwild.dll
+goto bu
+:bt
+set /a ax=0
+:bv
+set ay=!bk[%ax%]!
+if [!ay!]==[-help] ( goto bq ) else if [!ay!]==[-h] ( goto bq ) else if [!ay!]==[-?] ( goto bq )
+if [!ay!]==[-debug] (
+set am=1
+goto bw
+) else if [!ay!]==[-action] ( set /a "ax+=1" & call :bx bk[!ax!] v
+set wAction=!v!
+for %%g in (Restore, Configure, Update, Export, Recover, Unset, Upgrade, Default) do (
+if "!v!"=="%%g" goto bw
+)
+echo Unknown -action !v!
+exit/B 1
+) else if [!ay!]==[-sln-dir] ( set /a "ax+=1" & call :bx bk[!ax!] v
+set wSlnDir=!v!
+goto bw
+) else if [!ay!]==[-sln-file] ( set /a "ax+=1" & call :bx bk[!ax!] v
+set wSlnFile=!v!
+goto bw
+) else if [!ay!]==[-metalib] ( set /a "ax+=1" & call :bx bk[!ax!] v
+set wMetaLib=!v!
+goto bw
+) else if [!ay!]==[-metacor] ( set /a "ax+=1" & call :bx bk[!ax!] v
+set wMetaCor=!v!
+goto bw
+) else if [!ay!]==[-dxp-target] ( set /a "ax+=1" & call :bx bk[!ax!] v
+set wDxpTarget=!v!
+goto bw
+) else if [!ay!]==[-dxp-version] ( set /a "ax+=1" & call :bx bk[!ax!] v
+set af=!v!
+goto bw
+) else if [!ay!]==[-msb] ( set /a "ax+=1" & call :bx bk[!ax!] v
+set ao=!v!
+goto bw
+) else if [!ay!]==[-packages] ( set /a "ax+=1" & call :bx bk[!ax!] v
+set ai=!v!
+goto bw
+) else if [!ay!]==[-server] ( set /a "ax+=1" & call :bx bk[!ax!] v
+set aj=!v!
+goto bw
+) else if [!ay!]==[-proxy] ( set /a "ax+=1" & call :bx bk[!ax!] v
+set at=!v!
+set wProxy=!v!
+goto bw
+) else if [!ay!]==[-pkg-link] ( set /a "ax+=1" & call :bx bk[!ax!] v
+set ap=!v!
+set af=!ay!
+goto bw
+) else if [!ay!]==[-force] (
+set ar=1
+goto bw
+) else if [!ay!]==[-no-mgr] (
+set /a wDxpOpt^|=1
+goto bw
+) else if [!ay!]==[-mgr-up] (
+set as=1
+goto bw
+) else if [!ay!]==[-wz-target] ( set /a "ax+=1" & call :bx bk[!ax!] v
+set ah=!v!
+goto bw
+) else if [!ay!]==[-pe-exp-list] ( set /a "ax+=1" & call :bx bk[!ax!] v
+set aq=!v!
+goto bw
+) else if [!ay!]==[-eng] (
+chcp 437 >nul
+goto bw
+) else if [!ay!]==[-GetNuTool] (
+call :by -GetNuTool 10
+set /a aw=!ERRORLEVEL! & goto bu
+) else if [!ay!]==[-hMSBuild] (
+set av=1 & goto br
+) else if [!ay!]==[-version] (
+@echo v1.7.4.29858+c1cc52f  %__dxp_pv%
+goto bu
+) else if [!ay!]==[-build-info] (
+set an=1
+goto bw
+) else if [!ay!]==[-tests] ( set /a "ax+=1" & call :bx bk[!ax!] v
+set au=!v!
+goto bw
+) else (
+echo Incorrect key: !ay!
+set /a aw=1
+goto bu
+)
+:bw
+set /a "ax+=1" & if %ax% LSS !bl! goto bv
+:br
+call :bz "dxpName = " ag
+call :bz "dxpVersion = " af
+call :bz "-sln-dir = " wSlnDir
+call :bz "-sln-file = " wSlnFile
+call :bz "-metalib = " wMetaLib
+call :bz "-metacor = " wMetaCor
+call :bz "-dxp-target = " wDxpTarget
+call :bz "-wz-target = " ah
+call :bz "#opt " wDxpOpt
+if defined af (
+if "!af!"=="actual" (
+set "af="
+)
+)
+set wPkgVer=!af!
+if z%wAction%==zUpgrade (
+call :bz "Upgrade is on"
+set as=1
+set ar=1
+)
+call :b0 ai
+set "ai=!ai!\\"
+set "az=!ag!"
+set "wPkgPath=!ai!!ag!"
+if defined af (
+set "az=!az!/!af!"
+set "wPkgPath=!wPkgPath!.!af!"
+)
+if defined ar (
+if exist "!wPkgPath!" (
+call :bz "Removing old version before continue. '-force' key rule. " wPkgPath
+rmdir /S/Q "!wPkgPath!"
+)
+)
+set a0="!wPkgPath!\\!ah!"
+call :bz "wPkgPath = " wPkgPath
+if not exist !a0! (
+if exist "!wPkgPath!" (
+call :bz "Trying to replace obsolete version ... " wPkgPath
+rmdir /S/Q "!wPkgPath!"
+)
+call :bz "-pkg-link = " ap
+call :bz "-server = " aj
+if defined ap (
+set aj=!ap!
+if "!aj::=!"=="!aj!" (
+set aj=!cd!/!aj!
+)
+if "!wPkgPath::=!"=="!wPkgPath!" (
+set "a1=../"
+)
+set "az=:!a1!!wPkgPath!|"
+)
+if defined ao (
+set a2=-msbuild "!ao!"
+)
+set a3=!a2! /p:ngserver="!aj!" /p:ngpackages="!az!" /p:ngpath="!ai!" /p:proxycfg="!at! "
+call :bz "GetNuTool call: " a3
+if defined am (
+call :b1 !a3!
+) else (
+call :b1 !a3! >nul
+)
+)
+if defined av (
+call :by -hMSBuild 9
+set /a aw=!ERRORLEVEL! & goto bu
+)
+if defined aq (
+"!wPkgPath!\\tools\\PeViewer.exe" -list -pemodule "!aq!"
+set /a aw=%ERRORLEVEL%
+goto bu
+)
+if defined an (
+call :bz "buildInfo = " wPkgPath ak
+if not exist "!wPkgPath!\\!ak!" (
+echo information about build is not available.
+set /a aw=2
+goto bu
+)
+type "!wPkgPath!\\!ak!"
+goto bu
+)
+if not exist !a0! (
+echo Something went wrong. Try to use another keys.
+set /a aw=2
+goto bu
+)
+call :bz "wRootPath = " wRootPath
+call :bz "wAction = " wAction
+call :bz "wMgrArgs = " wMgrArgs
+if defined ao (
+call :bz "Use specific MSBuild tools: " ao
+set a4="!ao!"
+goto b2
+)
+call :b3 bm & set a4="!bm!"
+if "!ERRORLEVEL!"=="0" goto b2
+echo MSBuild tools was not found. Try with `-msb` key.
+set /a aw=2
+goto bu
+:b2
+if not defined a4 (
+echo Something went wrong. Use `-debug` key for details.
+set /a aw=2
+goto bu
+)
+if not defined au (
+if not defined ao if defined wPkgPath (
+set a4="!wPkgPath!\\hMSBuild"
+for /f "tokens=*" %%i in ('!a4! -version') do set a5=%%i
+call :b4 !a5! bn
+call :bz "hMSBuild -v" a5 bn
+if !bn! GEQ 230 (
+call :bz "2.3+"
+set a4=!a4! -vsw-as "-requiresAny -requires Microsoft.NetCore.Component.SDK Microsoft.Net.Core.Component.SDK -products * -latest -prerelease"
+)
+)
+call :bz "Target: " a4 a0
+call !a4! /nologo /v:m /m:4 !a0!
+)
+:bu
+if defined au (
+echo Running Tests ... "!au!"
+call :b3 bo
+"!bo!" /nologo /v:m /m:4 "!au!"
+exit/B 0
+)
+if defined as (
+(copy /B/Y "!wPkgPath!\\DllExport.bat" "!al!" > nul) && ( echo Manager has been updated. & exit/B 0 ) || ( (echo -mgr-up failed:!aw! 1>&2) & exit/B 1 )
+)
+exit/B !aw!
+:b4
+set a6=%~1
+for /f "tokens=1,2 delims=." %%a in ("!a6!") do (
+set _=%%b & set /a _*=10 & set /a %2=%%a!_!
+)
+exit/B 0
+:by
+set ay=%~1
+set /a a7=%~2
+call :bz "accessing to !ay! ..."
+for /L %%p IN (0,1,8181) DO (
+if "!ad:~%%p,%a7%!"=="!ay!" (
+set a8=!ad:~%%p!
+set a9=!a8:~%a7%!
+if defined av (
+call "!wPkgPath!\\hMSBuild" !a9!
+) else (
+call :b1 !a9!
+)
+exit/B !ERRORLEVEL!
+)
+)
+call :bz "!ay! is corrupted: " ad
+exit/B 1
+:b3
+call :bz "Searching from .NET Framework - .NET 4.0, ..."
+for %%v in (4.0, 3.5, 2.0) do (
+call :b5 %%v Y & if defined Y (
+set %1=!Y!
+exit/B 0
+)
+)
+call :bz "msb -netfx: not found"
+set "%1="
+exit/B 2
+:b5
+call :bz "check %1"
+for /F "usebackq tokens=2* skip=2" %%a in (
+`reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\MSBuild\ToolsVersions\%1" /v MSBuildToolsPath 2^> nul`
+) do if exist %%b (
+set a_=%%~b
+call :bz ":msbfound " a_
+call :b6 a_ bp
+set %2=!bp!
+exit/B 0
+)
+set "%2="
+exit/B 0
+:b6
+set %2=!%~1!\MSBuild.exe
+exit/B 0
+:bz
+if defined am (
+set ba=%1
+set ba=!ba:~0,-1!
+set ba=!ba:~1!
+echo.[%TIME% ] !ba! !%2! !%3!
+)
+exit/B 0
+:b0
+call :b7 %1
+call :b8 %1
+exit/B 0
+:b7
+call :b9 %1 "-=1"
+exit/B 0
+:b8
+call :b9 %1 "+=1"
+exit/B 0
+:b9
+set bb=z!%1!z
+if "%~2"=="-=1" (set "bc=1") else (set "bc=")
+if defined bc (
+set /a "i=-2"
+) else (
+set /a "i=1"
+)
+:b_
+if "!bb:~%i%,1!"==" " (
+set /a "i%~2"
+goto b_
+)
+if defined bc set /a "i+=1"
+if defined bc (
+set "%1=!bb:~1,%i%!"
+) else (
+set "%1=!bb:~%i%,-1!"
+)
+exit/B 0
+:bs
+set "bd=%~1"
+set /a ax=-1
+:ca
+set /a ax+=1
+set %bd%[!ax!]=%~2
+shift & if not "%~3"=="" goto ca
+set /a ax-=1
+set %1=!ax!
+exit/B 0
+:bx
+set %2=!%1!
+exit/B 0
+:b1
+setlocal disableDelayedExpansion
+@echo off
+:: GetNuTool - Executable version
+:: Copyright (c) 2015-2018,2020  Denis Kuzmin [ x-3F@outlook.com ]
+:: https://github.com/3F/GetNuTool
+set be=gnt.core
+set bf="%temp%\%random%%random%%be%"
+if "%~1"=="-unpack" goto cb
+set bg=%*
+if defined __p_call if defined bg set bg=%bg:^^=^%
+set bh=%__p_msb%
+if defined bh goto cc
+if "%~1"=="-msbuild" goto cd
+for %%v in (4.0, 14.0, 12.0, 3.5, 2.0) do (
+for /F "usebackq tokens=2* skip=2" %%a in (
+`reg query "HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\MSBuild\ToolsVersions\%%v" /v MSBuildToolsPath 2^> nul`
+) do if exist %%b (
+set bh="%%~b\MSBuild.exe"
+goto cc
+)
+)
+echo MSBuild was not found. Try -msbuild "fullpath" args 1>&2
+exit/B 2
+:cd
+shift
+set bh=%1
+shift
+set bi=%bg:!= #__b_ECL## %
+setlocal enableDelayedExpansion
+set bi=!bi:%%=%%%%!
+:ce
+for /F "tokens=1* delims==" %%a in ("!bi!") do (
+if "%%~b"=="" (
+call :cf !bi!
+exit/B %ERRORLEVEL%
+)
+set bi=%%a #__b_EQ## %%b
+)
+goto ce
+:cf
+shift & shift
+set "bg="
+:cg
+set bg=!bg! %1
+shift & if not "%~2"=="" goto cg
+set bg=!bg: #__b_EQ## ==!
+setlocal disableDelayedExpansion
+set bg=%bg: #__b_ECL## =!%
+:cc
+call :ch
+call %bh% %bf% /nologo /p:wpath="%cd%/" /v:m /m:4 %bg%
+set "bh="
+set bj=%ERRORLEVEL%
+del /Q/F %bf%
+exit/B %bj%
+:cb
+set bf="%cd%\%be%"
+echo Generating minified version in %bf% ...
+:ch
+<nul set /P ="">%bf%
+set a=PropertyGroup&set b=Condition&set c=ngpackages&set d=Target&set e=DependsOnTargets&set f=TaskCoreDllPath&set g=MSBuildToolsPath&set h=UsingTask&set i=CodeTaskFactory&set j=ParameterGroup&set k=Reference&set l=Include&set m=System&set n=Using&set o=Namespace&set p=IsNullOrEmpty&set q=return&set r=string&set s=delegate&set t=foreach&set u=WriteLine&set v=Combine&set w=Console.WriteLine&set x=Directory&set y=GetNuTool&set z=StringComparison&set _=EXT_NUSPEC
+<nul set /P =^<!-- GetNuTool - github.com/3F/GetNuTool --^>^<!-- Copyright (c) 2015-2018,2020  Denis Kuzmin [ x-3F@outlook.com ] --^>^<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003"^>^<%a%^>^<ngconfig %b%="'$(ngconfig)'==''"^>packages.config^</ngconfig^>^<ngserver %b%="'$(ngserver)'==''"^>https://www.nuget.org/api/v2/package/^</ngserver^>^<%c% %b%="'$(%c%)'==''"^>^</%c%^>^<ngpath %b%="'$(ngpath)'==''"^>packages^</ngpath^>^</%a%^>^<%d% Name="get" BeforeTargets="Build" %e%="header"^>^<a^>^<Output PropertyName="plist" TaskParameter="Result"/^>^</a^>^<b plist="$(plist)"/^>^</%d%^>^<%d% Name="pack" %e%="header"^>^<c/^>^</%d%^>^<%a%^>^<%f% %b%="Exists('$(%g%)\Microsoft.Build.Tasks.v$(MSBuildToolsVersion).dll')"^>$(%g%)\Microsoft.Build.Tasks.v$(MSBuildToolsVersion).dll^</%f%^>^<%f% %b%="'$(%f%)'=='' and Exists('$(%g%)\Microsoft.Build.Tasks.Core.dll')"^>$(%g%)\Microsoft.Build.Tasks.Core.dll^</%f%^>^</%a%^>^<%h% TaskName="a" TaskFactory="%i%" AssemblyFile="$(%f%)"^>^<%j%^>^<Result Output="true"/^>^</%j%^>^<Task^>^<%k% %l%="%m%.Xml"/^>^<%k% %l%="%m%.Xml.Linq"/^>^<%n% %o%="%m%"/^>^<%n% %o%="%m%.Collections.Generic"/^>^<%n% %o%="%m%.IO"/^>^<%n% %o%="%m%.Xml.Linq"/^>^<Code Type="Fragment" Language="cs"^>^<![CDATA[var a=@"$(ngconfig)";var b=@"$(%c%)";var c=@"$(wpath)";if(!String.%p%(b)){Result=b;%q% true;}var d=Console.Error;Action^<%r%,Queue^<%r%^>^>e=%s%(%r% f,Queue^<%r%^>g){%t%(var h in XDocument.Load(f).Descendants("package")){var i=h.Attribute("id");var j=h.Attribute("version");var k=h.Attribute("output");if(i==null){d.%u%("'id' does not exist in '{0}'",f);%q%;}var l=i.Value;if(j!=null){l+="/"+j.Value;}if(k!=null){g.Enqueue(l+":"+k.Value);continue;}g.Enqueue(l);}};var m=new Queue^<%r%^>();%t%(var f in a.Split(new char[]{a.IndexOf('^|')!=-1?'^|':';'},(StringSplitOptions)1))>>%bf%
+<nul set /P ={var n=Path.%v%(c,f);if(File.Exists(n)){e(n,m);}else{d.%u%(".config '{0}' is not found.",n);}}if(m.Count^<1){d.%u%("Empty list. Use .config or /p:%c%\n");}else{Result=%r%.Join("|",m.ToArray());}]]^>^</Code^>^</Task^>^</%h%^>^<%h% TaskName="b" TaskFactory="%i%" AssemblyFile="$(%f%)"^>^<%j%^>^<plist/^>^</%j%^>^<Task^>^<%k% %l%="WindowsBase"/^>^<%n% %o%="%m%"/^>^<%n% %o%="%m%.IO"/^>^<%n% %o%="%m%.IO.Packaging"/^>^<%n% %o%="%m%.Net"/^>^<Code Type="Fragment" Language="cs"^>^<![CDATA[var a=@"$(ngserver)";var b=@"$(wpath)";var c=@"$(ngpath)";var d=@"$(proxycfg)".Trim();var e=@"$(debug)"=="true";if(plist==null){%q% false;}ServicePointManager.SecurityProtocol^|=SecurityProtocolType.Tls11^|SecurityProtocolType.Tls12;var f=new %r%[]{"/_rels/","/package/","/[Content_Types].xml"};Action^<%r%,object^>g=%s%(%r% h,object i){if(e){%w%(h,i);}};Func^<%r%,WebProxy^>j=%s%(%r% k){var l=k.Split('@');if(l.Length^<=1){%q% new WebProxy(l[0],false);}var m=l[0].Split(':');%q% new WebProxy(l[1],false){Credentials=new NetworkCredential(m[0],(m.Length^>1)?m[1]:null)};};Func^<%r%,%r%^>n=%s%(%r% i){%q% Path.%v%(b,i??"");};Action^<%r%,%r%,%r%^>o=%s%(%r% p,%r% q,%r% r){var s=Path.GetFullPath(n(r??q));if(%x%.Exists(s)){%w%("`{0}` was found in \"{1}\"",q,s);%q%;}Console.Write("Getting `{0}` ... ",p);var t=Path.%v%(Path.GetTempPath(),Guid.NewGuid().ToString());using(var u=new WebClient()){try{if(!String.%p%(d)){u.Proxy=j(d);}u.Headers.Add("User-Agent","%y% $(%y%)");u.UseDefaultCredentials=true;if(u.Proxy.Credentials==null){u.Proxy.Credentials=CredentialCache.DefaultCredentials;}u.DownloadFile(a+p,t);}catch(Exception v){Console.Error.%u%(v.Message);%q%;}}%w%("Extracting into \"{0}\"",s);using(var w=ZipPackage.Open(t,FileMode.Open,FileAccess.Read)){%t%(var x in w.GetParts()){var y=Uri.UnescapeDataString(x.Uri.OriginalString);if>>%bf%
+<nul set /P =(f.Any(z=^>y.StartsWith(z,%z%.Ordinal))){continue;}var _=Path.%v%(s,y.TrimStart('/'));g("- `{0}`",y);var aa=Path.GetDirectoryName(_);if(!%x%.Exists(aa)){%x%.CreateDirectory(aa);}using(Stream ab=x.GetStream(FileMode.Open,FileAccess.Read))using(var ac=File.OpenWrite(_)){try{ab.CopyTo(ac);}catch(FileFormatException v){g("[x]?crc: {0}",_);}}}}File.Delete(t);};%t%(var w in plist.Split(new char[]{plist.IndexOf('^|')!=-1?'^|':';'},(StringSplitOptions)1)){var ad=w.Split(new char[]{':'},2);var p=ad[0];var r=(ad.Length^>1)?ad[1]:null;var q=p.Replace('/','.');if(!String.%p%(c)){r=Path.%v%(c,r??q);}o(p,q,r);}]]^>^</Code^>^</Task^>^</%h%^>^<%h% TaskName="c" TaskFactory="%i%" AssemblyFile="$(%f%)"^>^<Task^>^<%k% %l%="%m%.Xml"/^>^<%k% %l%="%m%.Xml.Linq"/^>^<%k% %l%="WindowsBase"/^>^<%n% %o%="%m%"/^>^<%n% %o%="%m%.Collections.Generic"/^>^<%n% %o%="%m%.IO"/^>^<%n% %o%="%m%.Linq"/^>^<%n% %o%="%m%.IO.Packaging"/^>^<%n% %o%="%m%.Xml.Linq"/^>^<%n% %o%="%m%.Text.RegularExpressions"/^>^<Code Type="Fragment" Language="cs"^>^<![CDATA[var a=@"$(ngin)";var b=@"$(ngout)";var c=@"$(wpath)";var d=@"$(debug)"=="true";var %_%=".nuspec";var EXT_NUPKG=".nupkg";var TAG_META="metadata";var DEF_CONTENT_TYPE="application/octet";var MANIFEST_URL="http://schemas.microsoft.com/packaging/2010/07/manifest";var ID="id";var VER="version";Action^<%r%,object^>e=%s%(%r% f,object g){if(d){%w%(f,g);}};var h=Console.Error;a=Path.%v%(c,a);if(!%x%.Exists(a)){h.%u%("`{0}` is not found.",a);%q% false;}b=Path.%v%(c,b);var i=%x%.GetFiles(a,"*"+%_%,SearchOption.TopDirectoryOnly).FirstOrDefault();if(i==null){h.%u%("{0} is not found in `{1}`",%_%,a);%q% false;}%w%("Found {0}: `{1}`",%_%,i);var j=XDocument.Load(i).Root.Elements().FirstOrDefault(k=^>k.Name.LocalName==TAG_META);if(j==null){h.%u%("{0} does not contain {1}.",i,TAG_META);%q% false;}var l=>>%bf%
+<nul set /P =new Dictionary^<%r%,%r%^>();%t%(var m in j.Elements()){l[m.Name.LocalName.ToLower()]=m.Value;}if(l[ID].Length^>100^|^|!Regex.IsMatch(l[ID],@"^\w+([_.-]\w+)*$",RegexOptions.IgnoreCase^|RegexOptions.ExplicitCapture)){h.%u%("The format `{0}` is not correct.",ID);%q% false;}var n=new %r%[]{Path.%v%(a,"_rels"),Path.%v%(a,"package"),Path.%v%(a,"[Content_Types].xml")};var o=%r%.Format("{0}.{1}{2}",l[ID],l[VER],EXT_NUPKG);if(!String.IsNullOrWhiteSpace(b)){if(!%x%.Exists(b)){%x%.CreateDirectory(b);}o=Path.%v%(b,o);}%w%("Creating nupkg `{0}` ...",o);using(var p=Package.Open(o,FileMode.Create)){Uri q=new Uri(String.Format("/{0}{1}",l[ID],%_%),UriKind.Relative);p.CreateRelationship(q,TargetMode.Internal,MANIFEST_URL);%t%(var r in %x%.GetFiles(a,"*.*",SearchOption.AllDirectories)){if(n.Any(k=^>r.StartsWith(k,%z%.Ordinal))){continue;}%r% s;if(r.StartsWith(a,%z%.OrdinalIgnoreCase)){s=r.Substring(a.Length).TrimStart(Path.DirectorySeparatorChar);}else{s=r;}e("- `{0}`",s);var t=%r%.Join("/",s.Split('\\','/').Select(g=^>Uri.EscapeDataString(g)));Uri u=PackUriHelper.CreatePartUri(new Uri(t,UriKind.Relative));var v=p.CreatePart(u,DEF_CONTENT_TYPE,CompressionOption.Maximum);using(Stream w=v.GetStream())using(var x=new FileStream(r,FileMode.Open,FileAccess.Read)){x.CopyTo(w);}}Func^<%r%,%r%^>y=%s%(%r% z){%q%(l.ContainsKey(z))?l[z]:"";};var _=p.PackageProperties;_.Creator=y("authors");_.Description=y("description");_.Identifier=l[ID];_.Version=l[VER];_.Keywords=y("tags");_.Title=y("title");_.LastModifiedBy="%y% $(%y%)";}]]^>^</Code^>^</Task^>^</%h%^>^<%d% Name="Build" %e%="get"/^>^<%a%^>^<%y%^>1.8.0.43837+df76082^</%y%^>^<wpath %b%="'$(wpath)'==''"^>$(MSBuildProjectDirectory)^</wpath^>^</%a%^>^<%d% Name="header"^>^<Message Text="%%0D%%0A%y% $(%y%)%%0D%%0A(c) 2015-2018,2020  Denis Kuzmin [ x-3F@outlook.com ] GitHub/3F%%0D%%0A" >>%bf%
+<nul set /P =Importance="high"/^>^</%d%^>^</Project^>>>%bf%
+exit/B 0

--- a/ERC.net/ERC/ERC.Net.xml
+++ b/ERC.net/ERC/ERC.Net.xml
@@ -1119,6 +1119,12 @@
             sub list.
             </summary>
         </member>
+        <member name="M:ERC.Utilities.Win32Errors.GetLastWin32Error(System.Int32)">
+            <summary>
+            Gets a user friendly string message for a system error code
+            </summary>
+            <returns>Error string</returns>
+        </member>
         <member name="T:ERC.DisplayOutput">
             <summary> Provides output in various human readable formats of data from the library. </summary>
         </member>
@@ -1214,7 +1220,7 @@
             <param name="nxcompat">Remove NXCompat libraries.</param>
             <param name="osdll">Remove OS Dlls.</param>
             <param name="unwantedBytes">Addresses containing values in this byte array will be ignored.</param>
-            <param name="protection">String containing protection level returned pointers will.</param>
+            <param name="protection">String array containing protection level returned pointers will.</param>
             <returns></returns>
         </member>
         <member name="M:ERC.DisplayOutput.SearchModules(ERC.ProcessInfo,System.Int32,System.String,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Byte[],System.Collections.Generic.List{System.String},System.String)">
@@ -1231,7 +1237,7 @@
             <param name="osdll">Remove OS Dlls.</param>
             <param name="unwantedBytes">Addresses containing values in this byte array will be ignored.</param>
             <param name="modules">List of modules to be searched</param>
-            <param name="protection">String containing protection level returned pointers will.</param>
+            <param name="protection">String array containing protection level returned pointers will.</param>
             <returns></returns>
         </member>
         <member name="M:ERC.DisplayOutput.GetSEHJumps(ERC.ProcessInfo,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Byte[],System.String)">
@@ -1248,7 +1254,7 @@
             <param name="osdll">Remove OS Dlls.</param>
             <param name="unwantedBytes">Addresses containing values in this byte array will be ignored.</param>
             <param name="protection">String containing protection level returned pointers will.</param>
-            <returns>Returns an ErcResult containing a list of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
+            <returns>Returns an array of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
         </member>
         <member name="M:ERC.DisplayOutput.GetSEHJumps(ERC.ProcessInfo,System.Byte[],System.Collections.Generic.List{System.String})">
             <summary>
@@ -1259,7 +1265,7 @@
             <param name="info">The ProcessInfo object which will be searched for POP POP RET instructions</param>
             <param name="ptrsToExclude">Ptrs containing these byte values will be discarded.</param>
             <param name="excludes">Modules to be ignored when searching for the instruction sets.</param>
-            <returns>Returns an ErcResult containing a list of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
+            <returns>Returns an array of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
         </member>
         <member name="M:ERC.DisplayOutput.GetSEHJumpsUnicode(ERC.ProcessInfo,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Byte[],System.String)">
             <summary>
@@ -1275,7 +1281,7 @@
             <param name="osdll">Remove OS Dlls.</param>
             <param name="unwantedBytes">Addresses containing values in this byte array will be ignored.</param>
             <param name="protection">String containing protection level returned pointers will.</param>
-            <returns>Returns an ErcResult containing a list of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
+            <returns>Returns an array of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
         </member>
         <member name="M:ERC.DisplayOutput.GenerateByteArray(ERC.ErcCore,System.Byte[])">
             <summary>
@@ -1316,14 +1322,14 @@
             Produces output files containing information about the associated ROP chain, produces files containing ROP gadgets and the associated ROP chain.
             </summary>
             <param name="rcg">The ROP chain generator object</param>
-            <returns>Returns a List of strings</returns>
+            <returns>Returns an array of strings</returns>
         </member>
         <member name="M:ERC.DisplayOutput.RopChainGadgets64(ERC.Utilities.RopChainGenerator64)">
             <summary>
             Produces output files containing information about the associated ROP chain, produces files containing ROP gadgets and the associated ROP chain.
             </summary>
             <param name="rcg">The ROP chain generator object</param>
-            <returns>Returns a List of strings</returns>
+            <returns>Returns an array of strings</returns>
         </member>
         <member name="M:ERC.DisplayOutput.AssembleOpcodes(System.String[],System.UInt32)">
             <summary>
@@ -1364,14 +1370,50 @@
             <param name="hex">A string containing hex characters.</param>
             <returns>Returns a byte array.</returns>
         </member>
-        <member name="M:ERC.DisplayOutput.DumpMemory(ERC.ProcessInfo,System.IntPtr,System.Int32)">
+        <member name="M:ERC.DisplayOutput.DumpMemory(ERC.ProcessInfo,System.IntPtr,System.Int32,System.Boolean)">
             <summary>
             Reads a set of bytes from process memory and provides a string contianing the results.
             </summary>
             <param name="info">ProcessInfo object</param>
             <param name="startAddress">The address to start reading from.</param>
             <param name="length">The number of bytes to read.</param>
-            <returns>A string containing the bytes read from memroy</returns>
+            <param name="writeToFile">Bool indicating if output should be written to a file.</param>
+            <returns>A string containing the bytes read from memory</returns>
+        </member>
+        <member name="M:ERC.DisplayOutput.DumpHeap(ERC.HeapInfo,System.UInt64,System.String,System.Boolean)">
+            <summary>
+            Reads a set of bytes from a specific heap and provides a string contianing the results. Either HeapID or startAddress must be supplied. If both are supplied HeapID takes precedence.
+            </summary>
+            <param name="hi">HeapInfo object</param>
+            <param name="heapid">The ID of the heap to be dumped. (optional)</param>
+            <param name="hexStartAddress">The start address of the specific heap block to be dumped in hexadecimal. (optional)</param>
+            <param name="writeToFile">Bool indicating if output should be written to a file.(optional)</param>
+            <returns>A string containing the bytes read from memory</returns>
+        </member>
+        <member name="M:ERC.DisplayOutput.HeapStats(ERC.HeapInfo,System.UInt64,System.String,System.Boolean)">
+            <summary>
+            Returns statistics about the heap information gathered about the current process.
+            </summary>
+            <param name="hi"></param>
+            <returns>Returns an of strings</returns>
+        </member>
+        <member name="M:ERC.DisplayOutput.ListHeapIDs(ERC.HeapInfo)">
+            <summary>
+            Returns a list of IDs for each heap associated with the current process.
+            </summary>
+            <param name="hi">A HeapInfo object.</param>
+            <returns>Retruns an array of strings containing the heapIds.</returns>
+        </member>
+        <member name="M:ERC.DisplayOutput.SearchHeap(ERC.HeapInfo,System.Byte[],System.UInt64,System.String,System.Boolean)">
+            <summary>
+            Searches the process heap for a specific byte patters. If heapID and hexStartAddress are specified heapID takes precedence. Takes an optional bool indicating if output should be written to file.
+            </summary>
+            <param name="hi">HeapInfo object.</param>
+            <param name="searchBytes">Pattern to be searched for.</param>
+            <param name="heapID">Optional parameter indicating which heap to search.</param>
+            <param name="hexStartAddress">Optional parameter indicating the start address of the heap object to search</param>
+            <param name="writeToFile">Bool indicating if the output should be written to file.</param>
+            <returns>Returns an array of strings.</returns>
         </member>
         <member name="T:ERC.ERCException">
             <summary>
@@ -1664,6 +1706,62 @@
             <param name="Dll">True if the file is a DLL, false if the file is an EXE.</param>
             <param name="readOnly">Boolean for the access mode.</param>
             <returns>If the function succeeds, the return value is TRUE.</returns>
+        </member>
+        <member name="M:ERC.ErcCore.CreateToolhelp32Snapshot(ERC.Structures.SnapshotFlags,System.UInt32)">
+            <summary>
+            Takes a snapshot of the specified processes, as well as the heaps, modules, and threads used by these processes.
+            </summary>
+            <param name="dwFlags">The portions of the system to be included in the snapshot. </param>
+            <param name="th32ProcessID">The process identifier of the process to be included in the snapshot. This parameter can be zero to indicate the current process. This parameter is used when the TH32CS_SNAPHEAPLIST, TH32CS_SNAPMODULE, TH32CS_SNAPMODULE32, or TH32CS_SNAPALL value is specified. Otherwise, it is ignored and all processes are included in the snapshot.</param>
+            <returns>If the function succeeds, it returns an open handle to the specified snapshot.</returns>
+        </member>
+        <member name="M:ERC.ErcCore.Process32First(System.IntPtr,ERC.Structures.PROCESSENTRY32@)">
+            <summary>
+            Retrieves information about the first process encountered in a system snapshot.
+            </summary>
+            <param name="hSnapshot">A handle to the snapshot returned from a previous call to the CreateToolhelp32Snapshot function.</param>
+            <param name="lppe">A pointer to a PROCESSENTRY32 structure.</param>
+            <returns>Returns TRUE if the first entry of the process list has been copied to the buffer or FALSE otherwise. </returns>
+        </member>
+        <member name="M:ERC.ErcCore.Process32Next(System.IntPtr,ERC.Structures.PROCESSENTRY32@)">
+            <summary>
+            Retrieves information about the next process recorded in a system snapshot.
+            </summary>
+            <param name="hSnapshot">A handle to the snapshot returned from a previous call to the CreateToolhelp32Snapshot function.</param>
+            <param name="lppe">A pointer to a PROCESSENTRY32 structure.</param>
+            <returns>Returns TRUE if the next entry of the process list has been copied to the buffer or FALSE otherwise.</returns>
+        </member>
+        <member name="M:ERC.ErcCore.Heap32ListFirst(System.IntPtr,ERC.Structures.HEAPLIST32@)">
+            <summary>
+            Retrieves information about the first heap that has been allocated by a specified process.
+            </summary>
+            <param name="hSnapshot">A handle to the snapshot returned from a previous call to the CreateToolhelp32Snapshot function.</param>
+            <param name="lphl">A pointer to a HEAPLIST32 structure.</param>
+            <returns>Returns TRUE if the first entry of the heap list has been copied to the buffer or FALSE otherwise.</returns>
+        </member>
+        <member name="M:ERC.ErcCore.Heap32ListNext(System.IntPtr,ERC.Structures.HEAPLIST32@)">
+            <summary>
+            Retrieves information about the next heap that has been allocated by a specified process.
+            </summary>
+            <param name="hSnapshot">A handle to the snapshot returned from a previous call to the CreateToolhelp32Snapshot function.</param>
+            <param name="lphl">A pointer to a HEAPLIST32 structure.</param>
+            <returns>Returns TRUE if the first entry of the heap list has been copied to the buffer or FALSE otherwise.</returns>
+        </member>
+        <member name="M:ERC.ErcCore.Heap32First(ERC.Structures.HEAPENTRY32@,System.UInt32,System.IntPtr)">
+            <summary>
+            Retrieves information about the first block of a heap that has been allocated by a process.
+            </summary>
+            <param name="heapentry32">A pointer to a HEAPENTRY32 structure.</param>
+            <param name="processID">The identifier of the process context that owns the heap.</param>
+            <param name="heapID">The identifier of the heap to be enumerated.</param>
+            <returns>Returns TRUE if information for the first heap block has been copied to the buffer or FALSE otherwise. </returns>
+        </member>
+        <member name="M:ERC.ErcCore.Heap32Next(ERC.Structures.HEAPENTRY32@)">
+            <summary>
+            Retrieves information about the next block of a heap that has been allocated by a process.
+            </summary>
+            <param name="heapentry32">A pointer to a HEAPENTRY32 structure.</param>
+            <returns>Returns TRUE if information about the next block in the heap has been copied to the buffer or FALSE otherwise. </returns>
         </member>
         <member name="M:ERC.ErcCore.#ctor">
             <summary>
@@ -4267,6 +4365,67 @@
             ThreadErrorMode
             </summary>
         </member>
+        <member name="T:ERC.Structures.SnapshotFlags">
+            <summary>
+            ToolHelp SnapshotFlags
+            </summary>
+        </member>
+        <member name="T:ERC.Structures.PROCESSENTRY32">
+            <summary>
+            ToolHelp PROCESSENTRY32
+            </summary>
+        </member>
+        <member name="T:ERC.Structures.HEAPLIST32">
+            <summary>
+            Describes one entry (block) of a heap that is being examined.
+            </summary>
+        </member>
+        <member name="T:ERC.Structures.HEAPENTRY32">
+            <summary>
+            Describes one entry (block) of a heap that is being examined.
+            </summary>
+        </member>
+        <member name="F:ERC.Structures.HEAPENTRY32.dwSize">
+            The size of the structure, in bytes *
+        </member>
+        <member name="F:ERC.Structures.HEAPENTRY32.hHandle">
+            A handle to the heap block *
+        </member>
+        <member name="F:ERC.Structures.HEAPENTRY32.dwAddress">
+            The linear address of the start of the block *
+        </member>
+        <member name="F:ERC.Structures.HEAPENTRY32.dwBlockSize">
+            The size of the heap block, in bytes *
+        </member>
+        <member name="F:ERC.Structures.HEAPENTRY32.dwFlags">
+            This member can be one of the following values.
+                            LF32_FIXED    0x00000001
+                           LF32_FREE     0x00000002
+                           LF32_MOVEABLE 0x00000004 *
+        </member>
+        <member name="F:ERC.Structures.HEAPENTRY32.dwLockCount">
+            This member is no longer used and is always set to zero. *
+        </member>
+        <member name="F:ERC.Structures.HEAPENTRY32.dwResvd">
+            Reserved; do not use or alter *
+        </member>
+        <member name="F:ERC.Structures.HEAPENTRY32.th32ProcessID">
+            The identifier of the process that uses the heap *
+        </member>
+        <member name="F:ERC.Structures.HEAPENTRY32.th32HeapID">
+            The heap identifier. This is not a handle, and has meaning only to the tool help functions *
+        </member>
+        <member name="M:ERC.HeapInfo.SearchHeap(System.Byte[],System.UInt64,System.String)">
+            <summary>
+            Searches heap entries for a specified pattern. Returns pointers to all instances of the pattern. If heapID and startAddress are both supplied heapID takes precedence.
+            </summary>
+            <param name="searchBytes">byte array containing the pattern to search for</param>
+            <param name="heapID">ID of the heap to be searched(Optional)</param>
+            <param name="hexStartAddress">Start address of the heap entry to be searched in hexadecimal(Optional)</param>
+            <returns>Returns an ERCResult of IntPtr containing pointers to all instances of the pattern found.</returns>
+        </member>
+        <!-- Badly formed XML comment ignored for member "M:ERC.HeapInfo.HeapStatistics(System.Boolean,System.UInt64,System.String)" -->
+        <!-- Badly formed XML comment ignored for member "M:ERC.HeapInfo.HeapIDs" -->
         <member name="T:ERC.ModuleInfo">
             <summary>
             Contains all information relating to a specific module.
@@ -4469,7 +4628,7 @@
         </member>
         <member name="M:ERC.ProcessInfo.SearchProcessMemory(System.Byte[])">
             <summary>
-            Private function called from Search_Memory. Searches memory regions populated by the process for specific strings.
+            Private function called from Search_Memory. Searches memory regions populated by the process for specific patterns.
             </summary>
             <param name="searchBytes"> Takes a byte array as input to be searched for</param>
             <returns>Returns a list of IntPtr for each instance found.</returns>

--- a/ERC.net/ERC/ERC.Net.xml
+++ b/ERC.net/ERC/ERC.Net.xml
@@ -149,16 +149,6 @@
             <param name="machineType">a ERC.MachineType of either I386 or x64</param>
             <returns>Returns an ERC_Result containing associated instructions.</returns>
         </member>
-        <member name="M:ERC.Utilities.OpcodeDisassembler.Disassemble(System.Byte[],ERC.MachineType,ERC.ErcCore)">
-            <summary>
-            Disassembles opcodes into the associated instructions. Takes a byte array containing opcodes, a MachineType of I386 or x64, 
-            an instance of the ERC_Core object and returns an ERC_Result containing associated instructions.
-            </summary>
-            <param name="opcodes">A byte array containing opcodes to be disassembled</param>
-            <param name="machineType">a ERC.MachineType of either I386 or x64</param>
-            <param name="core">a ErcCore object</param>
-            <returns>Returns an ERC_Result containing associated instructions.</returns>
-        </member>
         <member name="T:ERC.Utilities.PatternTools">
             <summary>
             Static class used to build a non repeating pattern and identify the position of a string in a non repeating pattern.
@@ -297,38 +287,20 @@
             <returns>Returns a Dictionary of Intptr, string</returns>
         </member>
         <member name="T:ERC.Utilities.RopChainGenerator32">
-            <summary> Attempts to create Rop chains from 32 bit processes. </summary>
+            <summary> Attempts to create Rop chains from 64 bit processes. </summary>
         </member>
         <member name="F:ERC.Utilities.RopChainGenerator32.VirtualAllocChain">
             <summary>
             Contains a ROP chain which calls the VirtualAlloc method.
             </summary>
         </member>
-        <member name="F:ERC.Utilities.RopChainGenerator32.HeapCreateChain">
+        <member name="M:ERC.Utilities.RopChainGenerator32.#ctor(ERC.ProcessInfo)">
             <summary>
-            Contains a ROP chain which calls the VirtualAlloc method.
+            Constructor.
             </summary>
+            <param name="_info">The ProcessInfo object.</param>
         </member>
-        <member name="F:ERC.Utilities.RopChainGenerator32.VirtualProtectChain">
-            <summary>
-            Contains a ROP chain which calls the VirtualAlloc method.
-            </summary>
-        </member>
-        <member name="F:ERC.Utilities.RopChainGenerator32.WriteProcessMemoryChain">
-            <summary>
-            Contains a ROP chain which calls the VirtualAlloc method.
-            </summary>
-        </member>
-        <!-- Badly formed XML comment ignored for member "M:ERC.Utilities.RopChainGenerator32.#ctor(ERC.ProcessInfo)" -->
-        <member name="M:ERC.Utilities.RopChainGenerator32.GenerateRopGadgets32(System.Byte[],System.Collections.Generic.List{System.String})">
-            <summary>
-            Creates a list of ROP gadgets for a specific process.
-            </summary>
-            <param name="ptrsToExclude">Takes a byte array of values used to disqualify ROP gadgets</param>
-            <param name="excludes">A list of modules to be excluded from the search for ROP gadgets</param>
-            <returns>Returns an ErcResult string containing</returns>
-        </member>
-        <member name="M:ERC.Utilities.RopChainGenerator32.GenerateRopChain32(System.Byte[],System.Byte[],System.Collections.Generic.List{System.String},ERC.Utilities.RopChainGenerator32.RopMethod)">
+        <member name="M:ERC.Utilities.RopChainGenerator32.GenerateRopChain32(System.Byte[],System.Byte[],System.Collections.Generic.List{System.String})">
             <summary>
             Creates a RopChain for a specific process.
             </summary>
@@ -337,13 +309,12 @@
             <param name="excludes">A list of modules to be excluded from the search for ROP gadgets</param>
             <returns>Returns an ErcResult string containing</returns>
         </member>
-        <member name="M:ERC.Utilities.RopChainGenerator32.GenerateRopChain32(System.Byte[],System.Collections.Generic.List{System.String},ERC.Utilities.RopChainGenerator32.RopMethod)">
+        <member name="M:ERC.Utilities.RopChainGenerator32.GenerateRopChain32(System.Byte[],System.Collections.Generic.List{System.String})">
             <summary>
             Creates a RopChain for a specific process.
             </summary>
-            <param name="startAddress">A Address to be used as the start location for which memory will be made executable.</param>
-            <param name="excludes">A list of modules to be excluded from the search for ROP gadgets.</param>
-            <param name="methods">Enum value representing which methods to build rop chains with.</param>
+            <param name="startAddress">A Address to be used as the start location for which memory will be made executable</param>
+            <param name="excludes">A list of modules to be excluded from the search for ROP gadgets</param>
             <returns>Returns an ErcResult string containing</returns>
         </member>
         <member name="M:ERC.Utilities.RopChainGenerator32.GetApiAddresses(ERC.ProcessInfo)">
@@ -641,30 +612,10 @@
             and list.
             </summary>
         </member>
-        <member name="T:ERC.Utilities.RopChainGenerator32.RopMethod">
-            <summary>
-            Enum of methods which can be used to generate a ROP chain.
-            </summary>
-        </member>
         <member name="T:ERC.Utilities.RopChainGenerator64">
             <summary> Attempts to create Rop chains from 64 bit processes. </summary>
         </member>
         <member name="F:ERC.Utilities.RopChainGenerator64.VirtualAllocChain">
-            <summary>
-            Contains a ROP chain which calls the VirtualAlloc method.
-            </summary>
-        </member>
-        <member name="F:ERC.Utilities.RopChainGenerator64.HeapCreateChain">
-            <summary>
-            Contains a ROP chain which calls the VirtualAlloc method.
-            </summary>
-        </member>
-        <member name="F:ERC.Utilities.RopChainGenerator64.VirtualProtectChain">
-            <summary>
-            Contains a ROP chain which calls the VirtualAlloc method.
-            </summary>
-        </member>
-        <member name="F:ERC.Utilities.RopChainGenerator64.WriteProcessMemoryChain">
             <summary>
             Contains a ROP chain which calls the VirtualAlloc method.
             </summary>
@@ -675,15 +626,7 @@
             </summary>
             <param name="_info">ProcessInfo object for which a ROP chain will be generated</param>
         </member>
-        <member name="M:ERC.Utilities.RopChainGenerator64.GenerateRopGadgets64(System.Byte[],System.Collections.Generic.List{System.String})">
-            <summary>
-            Creates a list of ROP gadgets for a specific process.
-            </summary>
-            <param name="ptrsToExclude">Takes a byte array of values used to disqualify ROP gadgets</param>
-            <param name="excludes">A list of modules to be excluded from the search for ROP gadgets</param>
-            <returns>Returns an ErcResult string containing</returns>
-        </member>
-        <member name="M:ERC.Utilities.RopChainGenerator64.GenerateRopChain64(System.Byte[],System.Byte[],System.Collections.Generic.List{System.String},ERC.Utilities.RopChainGenerator64.RopMethod)">
+        <member name="M:ERC.Utilities.RopChainGenerator64.GenerateRopChain64(System.Byte[],System.Byte[],System.Collections.Generic.List{System.String})">
             <summary>
             Creates a RopChain for a specific process.
             </summary>
@@ -692,7 +635,7 @@
             <param name="excludes">A list of modules to be excluded from the search for ROP gadgets</param>
             <returns>Returns an ErcResult string containing</returns>
         </member>
-        <member name="M:ERC.Utilities.RopChainGenerator64.GenerateRopChain64(System.Byte[],System.Collections.Generic.List{System.String},ERC.Utilities.RopChainGenerator64.RopMethod)">
+        <member name="M:ERC.Utilities.RopChainGenerator64.GenerateRopChain64(System.Byte[],System.Collections.Generic.List{System.String})">
             <summary>
             Creates a RopChain for a specific process.
             </summary>
@@ -1176,27 +1119,6 @@
             sub list.
             </summary>
         </member>
-        <member name="F:ERC.Utilities.RopChainGenerator64.X64Lists.callRax">
-            <summary>
-            jmpRax list.
-            </summary>
-        </member>
-        <member name="F:ERC.Utilities.RopChainGenerator64.X64Lists.jmpRax">
-            <summary>
-            callRax list.
-            </summary>
-        </member>
-        <member name="T:ERC.Utilities.RopChainGenerator64.RopMethod">
-            <summary>
-            Enum of methods which can be used to generate a ROP chain.
-            </summary>
-        </member>
-        <member name="M:ERC.Utilities.Win32Errors.GetLastWin32Error(System.Int32)">
-            <summary>
-            Gets a user friendly string message for a system error code
-            </summary>
-            <returns>Error string</returns>
-        </member>
         <member name="T:ERC.DisplayOutput">
             <summary> Provides output in various human readable formats of data from the library. </summary>
         </member>
@@ -1292,7 +1214,7 @@
             <param name="nxcompat">Remove NXCompat libraries.</param>
             <param name="osdll">Remove OS Dlls.</param>
             <param name="unwantedBytes">Addresses containing values in this byte array will be ignored.</param>
-            <param name="protection">String array containing protection level returned pointers will.</param>
+            <param name="protection">String containing protection level returned pointers will.</param>
             <returns></returns>
         </member>
         <member name="M:ERC.DisplayOutput.SearchModules(ERC.ProcessInfo,System.Int32,System.String,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Byte[],System.Collections.Generic.List{System.String},System.String)">
@@ -1309,7 +1231,7 @@
             <param name="osdll">Remove OS Dlls.</param>
             <param name="unwantedBytes">Addresses containing values in this byte array will be ignored.</param>
             <param name="modules">List of modules to be searched</param>
-            <param name="protection">String array containing protection level returned pointers will.</param>
+            <param name="protection">String containing protection level returned pointers will.</param>
             <returns></returns>
         </member>
         <member name="M:ERC.DisplayOutput.GetSEHJumps(ERC.ProcessInfo,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Byte[],System.String)">
@@ -1326,7 +1248,7 @@
             <param name="osdll">Remove OS Dlls.</param>
             <param name="unwantedBytes">Addresses containing values in this byte array will be ignored.</param>
             <param name="protection">String containing protection level returned pointers will.</param>
-            <returns>Returns an array of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
+            <returns>Returns an ErcResult containing a list of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
         </member>
         <member name="M:ERC.DisplayOutput.GetSEHJumps(ERC.ProcessInfo,System.Byte[],System.Collections.Generic.List{System.String})">
             <summary>
@@ -1337,7 +1259,7 @@
             <param name="info">The ProcessInfo object which will be searched for POP POP RET instructions</param>
             <param name="ptrsToExclude">Ptrs containing these byte values will be discarded.</param>
             <param name="excludes">Modules to be ignored when searching for the instruction sets.</param>
-            <returns>Returns an array of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
+            <returns>Returns an ErcResult containing a list of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
         </member>
         <member name="M:ERC.DisplayOutput.GetSEHJumpsUnicode(ERC.ProcessInfo,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Byte[],System.String)">
             <summary>
@@ -1353,7 +1275,7 @@
             <param name="osdll">Remove OS Dlls.</param>
             <param name="unwantedBytes">Addresses containing values in this byte array will be ignored.</param>
             <param name="protection">String containing protection level returned pointers will.</param>
-            <returns>Returns an array of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
+            <returns>Returns an ErcResult containing a list of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
         </member>
         <member name="M:ERC.DisplayOutput.GenerateByteArray(ERC.ErcCore,System.Byte[])">
             <summary>
@@ -1389,21 +1311,19 @@
             <param name="extended">Whether the extended character range is to be used when searching for the non repeating pattern</param>
             <returns>Returns a List of strings containing the locations the repeating pattern was identified</returns>
         </member>
-        <member name="M:ERC.DisplayOutput.RopChainGadgets32(ERC.Utilities.RopChainGenerator32,System.Boolean)">
+        <member name="M:ERC.DisplayOutput.RopChainGadgets32(ERC.Utilities.RopChainGenerator32)">
             <summary>
             Produces output files containing information about the associated ROP chain, produces files containing ROP gadgets and the associated ROP chain.
             </summary>
             <param name="rcg">The ROP chain generator object</param>
-            <param name="gadgetsOnly">Bool to indicate if ROP chains should be included or just gadget lists generated</param>
-            <returns>Returns an array of strings</returns>
+            <returns>Returns a List of strings</returns>
         </member>
-        <member name="M:ERC.DisplayOutput.RopChainGadgets64(ERC.Utilities.RopChainGenerator64,System.Boolean)">
+        <member name="M:ERC.DisplayOutput.RopChainGadgets64(ERC.Utilities.RopChainGenerator64)">
             <summary>
             Produces output files containing information about the associated ROP chain, produces files containing ROP gadgets and the associated ROP chain.
             </summary>
             <param name="rcg">The ROP chain generator object</param>
-            <param name="gadgetsOnly">Bool to indicate if ROP chains should be included or just gadget lists generated</param>
-            <returns>Returns an array of strings</returns>
+            <returns>Returns a List of strings</returns>
         </member>
         <member name="M:ERC.DisplayOutput.AssembleOpcodes(System.String[],System.UInt32)">
             <summary>
@@ -1444,50 +1364,14 @@
             <param name="hex">A string containing hex characters.</param>
             <returns>Returns a byte array.</returns>
         </member>
-        <member name="M:ERC.DisplayOutput.DumpMemory(ERC.ProcessInfo,System.IntPtr,System.Int32,System.Boolean)">
+        <member name="M:ERC.DisplayOutput.DumpMemory(ERC.ProcessInfo,System.IntPtr,System.Int32)">
             <summary>
             Reads a set of bytes from process memory and provides a string contianing the results.
             </summary>
             <param name="info">ProcessInfo object</param>
             <param name="startAddress">The address to start reading from.</param>
             <param name="length">The number of bytes to read.</param>
-            <param name="writeToFile">Bool indicating if output should be written to a file.</param>
-            <returns>A string containing the bytes read from memory</returns>
-        </member>
-        <member name="M:ERC.DisplayOutput.DumpHeap(ERC.HeapInfo,System.UInt64,System.String,System.Boolean)">
-            <summary>
-            Reads a set of bytes from a specific heap and provides a string contianing the results. Either HeapID or startAddress must be supplied. If both are supplied HeapID takes precedence.
-            </summary>
-            <param name="hi">HeapInfo object</param>
-            <param name="heapid">The ID of the heap to be dumped. (optional)</param>
-            <param name="hexStartAddress">The start address of the specific heap block to be dumped in hexadecimal. (optional)</param>
-            <param name="writeToFile">Bool indicating if output should be written to a file.(optional)</param>
-            <returns>A string containing the bytes read from memory</returns>
-        </member>
-        <member name="M:ERC.DisplayOutput.HeapStats(ERC.HeapInfo,System.UInt64,System.String,System.Boolean)">
-            <summary>
-            Returns statistics about the heap information gathered about the current process.
-            </summary>
-            <param name="hi"></param>
-            <returns>Returns an of strings</returns>
-        </member>
-        <member name="M:ERC.DisplayOutput.ListHeapIDs(ERC.HeapInfo)">
-            <summary>
-            Returns a list of IDs for each heap associated with the current process.
-            </summary>
-            <param name="hi">A HeapInfo object.</param>
-            <returns>Retruns an array of strings containing the heapIds.</returns>
-        </member>
-        <member name="M:ERC.DisplayOutput.SearchHeap(ERC.HeapInfo,System.Byte[],System.UInt64,System.String,System.Boolean)">
-            <summary>
-            Searches the process heap for a specific byte patters. If heapID and hexStartAddress are specified heapID takes precedence. Takes an optional bool indicating if output should be written to file.
-            </summary>
-            <param name="hi">HeapInfo object.</param>
-            <param name="searchBytes">Pattern to be searched for.</param>
-            <param name="heapID">Optional parameter indicating which heap to search.</param>
-            <param name="hexStartAddress">Optional parameter indicating the start address of the heap object to search</param>
-            <param name="writeToFile">Bool indicating if the output should be written to file.</param>
-            <returns>Returns an array of strings.</returns>
+            <returns>A string containing the bytes read from memroy</returns>
         </member>
         <member name="T:ERC.ERCException">
             <summary>
@@ -1780,62 +1664,6 @@
             <param name="Dll">True if the file is a DLL, false if the file is an EXE.</param>
             <param name="readOnly">Boolean for the access mode.</param>
             <returns>If the function succeeds, the return value is TRUE.</returns>
-        </member>
-        <member name="M:ERC.ErcCore.CreateToolhelp32Snapshot(ERC.Structures.SnapshotFlags,System.UInt32)">
-            <summary>
-            Takes a snapshot of the specified processes, as well as the heaps, modules, and threads used by these processes.
-            </summary>
-            <param name="dwFlags">The portions of the system to be included in the snapshot. </param>
-            <param name="th32ProcessID">The process identifier of the process to be included in the snapshot. This parameter can be zero to indicate the current process. This parameter is used when the TH32CS_SNAPHEAPLIST, TH32CS_SNAPMODULE, TH32CS_SNAPMODULE32, or TH32CS_SNAPALL value is specified. Otherwise, it is ignored and all processes are included in the snapshot.</param>
-            <returns>If the function succeeds, it returns an open handle to the specified snapshot.</returns>
-        </member>
-        <member name="M:ERC.ErcCore.Process32First(System.IntPtr,ERC.Structures.PROCESSENTRY32@)">
-            <summary>
-            Retrieves information about the first process encountered in a system snapshot.
-            </summary>
-            <param name="hSnapshot">A handle to the snapshot returned from a previous call to the CreateToolhelp32Snapshot function.</param>
-            <param name="lppe">A pointer to a PROCESSENTRY32 structure.</param>
-            <returns>Returns TRUE if the first entry of the process list has been copied to the buffer or FALSE otherwise. </returns>
-        </member>
-        <member name="M:ERC.ErcCore.Process32Next(System.IntPtr,ERC.Structures.PROCESSENTRY32@)">
-            <summary>
-            Retrieves information about the next process recorded in a system snapshot.
-            </summary>
-            <param name="hSnapshot">A handle to the snapshot returned from a previous call to the CreateToolhelp32Snapshot function.</param>
-            <param name="lppe">A pointer to a PROCESSENTRY32 structure.</param>
-            <returns>Returns TRUE if the next entry of the process list has been copied to the buffer or FALSE otherwise.</returns>
-        </member>
-        <member name="M:ERC.ErcCore.Heap32ListFirst(System.IntPtr,ERC.Structures.HEAPLIST32@)">
-            <summary>
-            Retrieves information about the first heap that has been allocated by a specified process.
-            </summary>
-            <param name="hSnapshot">A handle to the snapshot returned from a previous call to the CreateToolhelp32Snapshot function.</param>
-            <param name="lphl">A pointer to a HEAPLIST32 structure.</param>
-            <returns>Returns TRUE if the first entry of the heap list has been copied to the buffer or FALSE otherwise.</returns>
-        </member>
-        <member name="M:ERC.ErcCore.Heap32ListNext(System.IntPtr,ERC.Structures.HEAPLIST32@)">
-            <summary>
-            Retrieves information about the next heap that has been allocated by a specified process.
-            </summary>
-            <param name="hSnapshot">A handle to the snapshot returned from a previous call to the CreateToolhelp32Snapshot function.</param>
-            <param name="lphl">A pointer to a HEAPLIST32 structure.</param>
-            <returns>Returns TRUE if the first entry of the heap list has been copied to the buffer or FALSE otherwise.</returns>
-        </member>
-        <member name="M:ERC.ErcCore.Heap32First(ERC.Structures.HEAPENTRY32@,System.UInt32,System.IntPtr)">
-            <summary>
-            Retrieves information about the first block of a heap that has been allocated by a process.
-            </summary>
-            <param name="heapentry32">A pointer to a HEAPENTRY32 structure.</param>
-            <param name="processID">The identifier of the process context that owns the heap.</param>
-            <param name="heapID">The identifier of the heap to be enumerated.</param>
-            <returns>Returns TRUE if information for the first heap block has been copied to the buffer or FALSE otherwise. </returns>
-        </member>
-        <member name="M:ERC.ErcCore.Heap32Next(ERC.Structures.HEAPENTRY32@)">
-            <summary>
-            Retrieves information about the next block of a heap that has been allocated by a process.
-            </summary>
-            <param name="heapentry32">A pointer to a HEAPENTRY32 structure.</param>
-            <returns>Returns TRUE if information about the next block in the heap has been copied to the buffer or FALSE otherwise. </returns>
         </member>
         <member name="M:ERC.ErcCore.#ctor">
             <summary>
@@ -4439,67 +4267,6 @@
             ThreadErrorMode
             </summary>
         </member>
-        <member name="T:ERC.Structures.SnapshotFlags">
-            <summary>
-            ToolHelp SnapshotFlags
-            </summary>
-        </member>
-        <member name="T:ERC.Structures.PROCESSENTRY32">
-            <summary>
-            ToolHelp PROCESSENTRY32
-            </summary>
-        </member>
-        <member name="T:ERC.Structures.HEAPLIST32">
-            <summary>
-            Describes one entry (block) of a heap that is being examined.
-            </summary>
-        </member>
-        <member name="T:ERC.Structures.HEAPENTRY32">
-            <summary>
-            Describes one entry (block) of a heap that is being examined.
-            </summary>
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.dwSize">
-            The size of the structure, in bytes *
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.hHandle">
-            A handle to the heap block *
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.dwAddress">
-            The linear address of the start of the block *
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.dwBlockSize">
-            The size of the heap block, in bytes *
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.dwFlags">
-            This member can be one of the following values.
-                            LF32_FIXED    0x00000001
-                           LF32_FREE     0x00000002
-                           LF32_MOVEABLE 0x00000004 *
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.dwLockCount">
-            This member is no longer used and is always set to zero. *
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.dwResvd">
-            Reserved; do not use or alter *
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.th32ProcessID">
-            The identifier of the process that uses the heap *
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.th32HeapID">
-            The heap identifier. This is not a handle, and has meaning only to the tool help functions *
-        </member>
-        <member name="M:ERC.HeapInfo.SearchHeap(System.Byte[],System.UInt64,System.String)">
-            <summary>
-            Searches heap entries for a specified pattern. Returns pointers to all instances of the pattern. If heapID and startAddress are both supplied heapID takes precedence.
-            </summary>
-            <param name="searchBytes">byte array containing the pattern to search for</param>
-            <param name="heapID">ID of the heap to be searched(Optional)</param>
-            <param name="hexStartAddress">Start address of the heap entry to be searched in hexadecimal(Optional)</param>
-            <returns>Returns an ERCResult of IntPtr containing pointers to all instances of the pattern found.</returns>
-        </member>
-        <!-- Badly formed XML comment ignored for member "M:ERC.HeapInfo.HeapStatistics(System.Boolean,System.UInt64,System.String)" -->
-        <!-- Badly formed XML comment ignored for member "M:ERC.HeapInfo.HeapIDs" -->
         <member name="T:ERC.ModuleInfo">
             <summary>
             Contains all information relating to a specific module.
@@ -4702,7 +4469,7 @@
         </member>
         <member name="M:ERC.ProcessInfo.SearchProcessMemory(System.Byte[])">
             <summary>
-            Private function called from Search_Memory. Searches memory regions populated by the process for specific patterns.
+            Private function called from Search_Memory. Searches memory regions populated by the process for specific strings.
             </summary>
             <param name="searchBytes"> Takes a byte array as input to be searched for</param>
             <returns>Returns a list of IntPtr for each instance found.</returns>

--- a/ERC/ERC/Convert.cs
+++ b/ERC/ERC/Convert.cs
@@ -187,5 +187,17 @@ namespace ERC.Utilities
             return BitConverter.ToString(Encoding.UTF32.GetBytes(utf32)).Replace("-", " ");
         }
         #endregion
+
+        #region HTML
+        /// <summary>
+        /// Converts the spaces in a string to Html fixed width character.
+        /// </summary>
+        /// <param name="str">A UTF-8 string.</param>
+        /// <returns>A string with spaces converted to HTML entities.</returns>
+        public static string htmlWhitespaceFix(string str)
+        {
+            return str.Replace(" ", "&nbsp;");
+        }
+        #endregion
     }
 }

--- a/ERC/ERC/Display_Output.cs
+++ b/ERC/ERC/Display_Output.cs
@@ -6,6 +6,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using Convert = ERC.Utilities.Convert;
 
 namespace ERC
 {
@@ -1122,6 +1123,7 @@ namespace ERC
         #endregion
 
         #region CompareByteArrays
+
         /// <summary>
         /// Compares a the values contained in a memory region to the values in the supplied byte array.
         /// </summary>
@@ -1135,9 +1137,9 @@ namespace ERC
             byte[] memoryRegion = new byte[byteArray.Length];
             List<byte> mismatchingBytes = new List<byte>();
             int bytesRead = 0;
-            output.Add("                   ----------------------------------------------------");
-            string fromArray  = "        From Array | ";
-            string fromRegion = "From Memory Region | "; 
+            output.Add(Convert.htmlWhitespaceFix("                   ----------------------------------------------------"));
+            string fromArray  = Convert.htmlWhitespaceFix("        From Array | ");
+            string fromRegion = Convert.htmlWhitespaceFix("From Memory Region | "); 
             ErcCore.ReadProcessMemory(info.ProcessHandle, startAddress, memoryRegion, byteArray.Length, out bytesRead);
             int counter = 0;
             for(int i = 0; i <= byteArray.Length; i++)
@@ -1145,28 +1147,28 @@ namespace ERC
                 if (i == byteArray.Length)
                 {
                     counter = 0;
-                    fromArray += " | ";
-                    fromRegion += " | ";
-                    string newLine = "                   |                                                  | ";
+                    fromArray += Convert.htmlWhitespaceFix(" | ");
+                    fromRegion += Convert.htmlWhitespaceFix(" | ");
+                    string newLine = Convert.htmlWhitespaceFix("                   |                                                  | ");
                     output.Add(fromArray);
                     output.Add(fromRegion);
                     output.Add(newLine);
-                    fromArray = "        From Array | ";
-                    fromRegion = "From Memory Region | ";
+                    fromArray = Convert.htmlWhitespaceFix("        From Array | ");
+                    fromRegion = Convert.htmlWhitespaceFix("From Memory Region | ");
                 }
                 else
                 {
                     if (counter == 16)
                     {
                         counter = 0;
-                        fromArray += " | ";
-                        fromRegion += " | ";
-                        string newLine = "                   |                                                  | ";
+                        fromArray += Convert.htmlWhitespaceFix(" | ");
+                        fromRegion += Convert.htmlWhitespaceFix(" | ");
+                        string newLine = Convert.htmlWhitespaceFix("                   |                                                  | ");
                         output.Add(fromArray);
                         output.Add(fromRegion);
                         output.Add(newLine);
-                        fromArray = "        From Array | ";
-                        fromRegion = "From Memory Region | ";
+                        fromArray = Convert.htmlWhitespaceFix("        From Array | ");
+                        fromRegion = Convert.htmlWhitespaceFix("From Memory Region | ");
                     }
 
                     byte[] thisByte = new byte[1];
@@ -1174,9 +1176,9 @@ namespace ERC
                     if (byteArray[i] != memoryRegion[i])
                     {
                         mismatchingBytes.Add(byteArray[i]);
-                        fromArray += "[color@red]" + BitConverter.ToString(thisByte) + "[stopcolor]";
+                        fromArray += "<b><span style='color:red;'>" + BitConverter.ToString(thisByte) + "</span></b>";
                         thisByte[0] = memoryRegion[i];
-                        fromRegion += "[color@red]" + BitConverter.ToString(thisByte) + "[stopcolor]";
+                        fromRegion += "<b><span style='color:red;'>" + BitConverter.ToString(thisByte) + "</span></b>";
                     }
                     else
                     {
@@ -1185,12 +1187,12 @@ namespace ERC
                         fromRegion += BitConverter.ToString(thisByte);
                     }
 
-                    fromArray += " ";
-                    fromRegion += " ";
+                    fromArray += Convert.htmlWhitespaceFix(" ");
+                    fromRegion += Convert.htmlWhitespaceFix(" ");
                     counter++;
                 }
             }
-            output.Add("                   ----------------------------------------------------");
+            output.Add(Convert.htmlWhitespaceFix("                   ----------------------------------------------------"));
             output.Add("Mismatching Bytes: [" + String.Join(", ", mismatchingBytes.Select(b => BitConverter.ToString(new byte[]{b}))) + "]");
             if(mismatchingBytes.Count > 0)
             {

--- a/ERC/ERC/ERC.Net.xml
+++ b/ERC/ERC/ERC.Net.xml
@@ -149,16 +149,6 @@
             <param name="machineType">a ERC.MachineType of either I386 or x64</param>
             <returns>Returns an ERC_Result containing associated instructions.</returns>
         </member>
-        <member name="M:ERC.Utilities.OpcodeDisassembler.Disassemble(System.Byte[],ERC.MachineType,ERC.ErcCore)">
-            <summary>
-            Disassembles opcodes into the associated instructions. Takes a byte array containing opcodes, a MachineType of I386 or x64, 
-            an instance of the ERC_Core object and returns an ERC_Result containing associated instructions.
-            </summary>
-            <param name="opcodes">A byte array containing opcodes to be disassembled</param>
-            <param name="machineType">a ERC.MachineType of either I386 or x64</param>
-            <param name="core">a ErcCore object</param>
-            <returns>Returns an ERC_Result containing associated instructions.</returns>
-        </member>
         <member name="T:ERC.Utilities.PatternTools">
             <summary>
             Static class used to build a non repeating pattern and identify the position of a string in a non repeating pattern.
@@ -297,38 +287,20 @@
             <returns>Returns a Dictionary of Intptr, string</returns>
         </member>
         <member name="T:ERC.Utilities.RopChainGenerator32">
-            <summary> Attempts to create Rop chains from 32 bit processes. </summary>
+            <summary> Attempts to create Rop chains from 64 bit processes. </summary>
         </member>
         <member name="F:ERC.Utilities.RopChainGenerator32.VirtualAllocChain">
             <summary>
             Contains a ROP chain which calls the VirtualAlloc method.
             </summary>
         </member>
-        <member name="F:ERC.Utilities.RopChainGenerator32.HeapCreateChain">
+        <member name="M:ERC.Utilities.RopChainGenerator32.#ctor(ERC.ProcessInfo)">
             <summary>
-            Contains a ROP chain which calls the VirtualAlloc method.
+            Constructor.
             </summary>
+            <param name="_info">The ProcessInfo object.</param>
         </member>
-        <member name="F:ERC.Utilities.RopChainGenerator32.VirtualProtectChain">
-            <summary>
-            Contains a ROP chain which calls the VirtualAlloc method.
-            </summary>
-        </member>
-        <member name="F:ERC.Utilities.RopChainGenerator32.WriteProcessMemoryChain">
-            <summary>
-            Contains a ROP chain which calls the VirtualAlloc method.
-            </summary>
-        </member>
-        <!-- Badly formed XML comment ignored for member "M:ERC.Utilities.RopChainGenerator32.#ctor(ERC.ProcessInfo)" -->
-        <member name="M:ERC.Utilities.RopChainGenerator32.GenerateRopGadgets32(System.Byte[],System.Collections.Generic.List{System.String})">
-            <summary>
-            Creates a list of ROP gadgets for a specific process.
-            </summary>
-            <param name="ptrsToExclude">Takes a byte array of values used to disqualify ROP gadgets</param>
-            <param name="excludes">A list of modules to be excluded from the search for ROP gadgets</param>
-            <returns>Returns an ErcResult string containing</returns>
-        </member>
-        <member name="M:ERC.Utilities.RopChainGenerator32.GenerateRopChain32(System.Byte[],System.Byte[],System.Collections.Generic.List{System.String},ERC.Utilities.RopChainGenerator32.RopMethod)">
+        <member name="M:ERC.Utilities.RopChainGenerator32.GenerateRopChain32(System.Byte[],System.Byte[],System.Collections.Generic.List{System.String})">
             <summary>
             Creates a RopChain for a specific process.
             </summary>
@@ -337,13 +309,12 @@
             <param name="excludes">A list of modules to be excluded from the search for ROP gadgets</param>
             <returns>Returns an ErcResult string containing</returns>
         </member>
-        <member name="M:ERC.Utilities.RopChainGenerator32.GenerateRopChain32(System.Byte[],System.Collections.Generic.List{System.String},ERC.Utilities.RopChainGenerator32.RopMethod)">
+        <member name="M:ERC.Utilities.RopChainGenerator32.GenerateRopChain32(System.Byte[],System.Collections.Generic.List{System.String})">
             <summary>
             Creates a RopChain for a specific process.
             </summary>
-            <param name="startAddress">A Address to be used as the start location for which memory will be made executable.</param>
-            <param name="excludes">A list of modules to be excluded from the search for ROP gadgets.</param>
-            <param name="methods">Enum value representing which methods to build rop chains with.</param>
+            <param name="startAddress">A Address to be used as the start location for which memory will be made executable</param>
+            <param name="excludes">A list of modules to be excluded from the search for ROP gadgets</param>
             <returns>Returns an ErcResult string containing</returns>
         </member>
         <member name="M:ERC.Utilities.RopChainGenerator32.GetApiAddresses(ERC.ProcessInfo)">
@@ -641,30 +612,10 @@
             and list.
             </summary>
         </member>
-        <member name="T:ERC.Utilities.RopChainGenerator32.RopMethod">
-            <summary>
-            Enum of methods which can be used to generate a ROP chain.
-            </summary>
-        </member>
         <member name="T:ERC.Utilities.RopChainGenerator64">
             <summary> Attempts to create Rop chains from 64 bit processes. </summary>
         </member>
         <member name="F:ERC.Utilities.RopChainGenerator64.VirtualAllocChain">
-            <summary>
-            Contains a ROP chain which calls the VirtualAlloc method.
-            </summary>
-        </member>
-        <member name="F:ERC.Utilities.RopChainGenerator64.HeapCreateChain">
-            <summary>
-            Contains a ROP chain which calls the VirtualAlloc method.
-            </summary>
-        </member>
-        <member name="F:ERC.Utilities.RopChainGenerator64.VirtualProtectChain">
-            <summary>
-            Contains a ROP chain which calls the VirtualAlloc method.
-            </summary>
-        </member>
-        <member name="F:ERC.Utilities.RopChainGenerator64.WriteProcessMemoryChain">
             <summary>
             Contains a ROP chain which calls the VirtualAlloc method.
             </summary>
@@ -675,15 +626,7 @@
             </summary>
             <param name="_info">ProcessInfo object for which a ROP chain will be generated</param>
         </member>
-        <member name="M:ERC.Utilities.RopChainGenerator64.GenerateRopGadgets64(System.Byte[],System.Collections.Generic.List{System.String})">
-            <summary>
-            Creates a list of ROP gadgets for a specific process.
-            </summary>
-            <param name="ptrsToExclude">Takes a byte array of values used to disqualify ROP gadgets</param>
-            <param name="excludes">A list of modules to be excluded from the search for ROP gadgets</param>
-            <returns>Returns an ErcResult string containing</returns>
-        </member>
-        <member name="M:ERC.Utilities.RopChainGenerator64.GenerateRopChain64(System.Byte[],System.Byte[],System.Collections.Generic.List{System.String},ERC.Utilities.RopChainGenerator64.RopMethod)">
+        <member name="M:ERC.Utilities.RopChainGenerator64.GenerateRopChain64(System.Byte[],System.Byte[],System.Collections.Generic.List{System.String})">
             <summary>
             Creates a RopChain for a specific process.
             </summary>
@@ -692,7 +635,7 @@
             <param name="excludes">A list of modules to be excluded from the search for ROP gadgets</param>
             <returns>Returns an ErcResult string containing</returns>
         </member>
-        <member name="M:ERC.Utilities.RopChainGenerator64.GenerateRopChain64(System.Byte[],System.Collections.Generic.List{System.String},ERC.Utilities.RopChainGenerator64.RopMethod)">
+        <member name="M:ERC.Utilities.RopChainGenerator64.GenerateRopChain64(System.Byte[],System.Collections.Generic.List{System.String})">
             <summary>
             Creates a RopChain for a specific process.
             </summary>
@@ -1176,27 +1119,6 @@
             sub list.
             </summary>
         </member>
-        <member name="F:ERC.Utilities.RopChainGenerator64.X64Lists.callRax">
-            <summary>
-            jmpRax list.
-            </summary>
-        </member>
-        <member name="F:ERC.Utilities.RopChainGenerator64.X64Lists.jmpRax">
-            <summary>
-            callRax list.
-            </summary>
-        </member>
-        <member name="T:ERC.Utilities.RopChainGenerator64.RopMethod">
-            <summary>
-            Enum of methods which can be used to generate a ROP chain.
-            </summary>
-        </member>
-        <member name="M:ERC.Utilities.Win32Errors.GetLastWin32Error(System.Int32)">
-            <summary>
-            Gets a user friendly string message for a system error code
-            </summary>
-            <returns>Error string</returns>
-        </member>
         <member name="T:ERC.DisplayOutput">
             <summary> Provides output in various human readable formats of data from the library. </summary>
         </member>
@@ -1292,7 +1214,7 @@
             <param name="nxcompat">Remove NXCompat libraries.</param>
             <param name="osdll">Remove OS Dlls.</param>
             <param name="unwantedBytes">Addresses containing values in this byte array will be ignored.</param>
-            <param name="protection">String array containing protection level returned pointers will.</param>
+            <param name="protection">String containing protection level returned pointers will.</param>
             <returns></returns>
         </member>
         <member name="M:ERC.DisplayOutput.SearchModules(ERC.ProcessInfo,System.Int32,System.String,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Byte[],System.Collections.Generic.List{System.String},System.String)">
@@ -1309,7 +1231,7 @@
             <param name="osdll">Remove OS Dlls.</param>
             <param name="unwantedBytes">Addresses containing values in this byte array will be ignored.</param>
             <param name="modules">List of modules to be searched</param>
-            <param name="protection">String array containing protection level returned pointers will.</param>
+            <param name="protection">String containing protection level returned pointers will.</param>
             <returns></returns>
         </member>
         <member name="M:ERC.DisplayOutput.GetSEHJumps(ERC.ProcessInfo,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Byte[],System.String)">
@@ -1326,7 +1248,7 @@
             <param name="osdll">Remove OS Dlls.</param>
             <param name="unwantedBytes">Addresses containing values in this byte array will be ignored.</param>
             <param name="protection">String containing protection level returned pointers will.</param>
-            <returns>Returns an array of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
+            <returns>Returns an ErcResult containing a list of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
         </member>
         <member name="M:ERC.DisplayOutput.GetSEHJumps(ERC.ProcessInfo,System.Byte[],System.Collections.Generic.List{System.String})">
             <summary>
@@ -1337,7 +1259,7 @@
             <param name="info">The ProcessInfo object which will be searched for POP POP RET instructions</param>
             <param name="ptrsToExclude">Ptrs containing these byte values will be discarded.</param>
             <param name="excludes">Modules to be ignored when searching for the instruction sets.</param>
-            <returns>Returns an array of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
+            <returns>Returns an ErcResult containing a list of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
         </member>
         <member name="M:ERC.DisplayOutput.GetSEHJumpsUnicode(ERC.ProcessInfo,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Boolean,System.Byte[],System.String)">
             <summary>
@@ -1353,7 +1275,7 @@
             <param name="osdll">Remove OS Dlls.</param>
             <param name="unwantedBytes">Addresses containing values in this byte array will be ignored.</param>
             <param name="protection">String containing protection level returned pointers will.</param>
-            <returns>Returns an array of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
+            <returns>Returns an ErcResult containing a list of strings detailing the pointers, opcodes and base files of suitable instruction sets.</returns>
         </member>
         <member name="M:ERC.DisplayOutput.GenerateByteArray(ERC.ErcCore,System.Byte[])">
             <summary>
@@ -1389,21 +1311,19 @@
             <param name="extended">Whether the extended character range is to be used when searching for the non repeating pattern</param>
             <returns>Returns a List of strings containing the locations the repeating pattern was identified</returns>
         </member>
-        <member name="M:ERC.DisplayOutput.RopChainGadgets32(ERC.Utilities.RopChainGenerator32,System.Boolean)">
+        <member name="M:ERC.DisplayOutput.RopChainGadgets32(ERC.Utilities.RopChainGenerator32)">
             <summary>
             Produces output files containing information about the associated ROP chain, produces files containing ROP gadgets and the associated ROP chain.
             </summary>
             <param name="rcg">The ROP chain generator object</param>
-            <param name="gadgetsOnly">Bool to indicate if ROP chains should be included or just gadget lists generated</param>
-            <returns>Returns an array of strings</returns>
+            <returns>Returns a List of strings</returns>
         </member>
-        <member name="M:ERC.DisplayOutput.RopChainGadgets64(ERC.Utilities.RopChainGenerator64,System.Boolean)">
+        <member name="M:ERC.DisplayOutput.RopChainGadgets64(ERC.Utilities.RopChainGenerator64)">
             <summary>
             Produces output files containing information about the associated ROP chain, produces files containing ROP gadgets and the associated ROP chain.
             </summary>
             <param name="rcg">The ROP chain generator object</param>
-            <param name="gadgetsOnly">Bool to indicate if ROP chains should be included or just gadget lists generated</param>
-            <returns>Returns an array of strings</returns>
+            <returns>Returns a List of strings</returns>
         </member>
         <member name="M:ERC.DisplayOutput.AssembleOpcodes(System.String[],System.UInt32)">
             <summary>
@@ -1444,50 +1364,14 @@
             <param name="hex">A string containing hex characters.</param>
             <returns>Returns a byte array.</returns>
         </member>
-        <member name="M:ERC.DisplayOutput.DumpMemory(ERC.ProcessInfo,System.IntPtr,System.Int32,System.Boolean)">
+        <member name="M:ERC.DisplayOutput.DumpMemory(ERC.ProcessInfo,System.IntPtr,System.Int32)">
             <summary>
             Reads a set of bytes from process memory and provides a string contianing the results.
             </summary>
             <param name="info">ProcessInfo object</param>
             <param name="startAddress">The address to start reading from.</param>
             <param name="length">The number of bytes to read.</param>
-            <param name="writeToFile">Bool indicating if output should be written to a file.</param>
-            <returns>A string containing the bytes read from memory</returns>
-        </member>
-        <member name="M:ERC.DisplayOutput.DumpHeap(ERC.HeapInfo,System.UInt64,System.String,System.Boolean)">
-            <summary>
-            Reads a set of bytes from a specific heap and provides a string contianing the results. Either HeapID or startAddress must be supplied. If both are supplied HeapID takes precedence.
-            </summary>
-            <param name="hi">HeapInfo object</param>
-            <param name="heapid">The ID of the heap to be dumped. (optional)</param>
-            <param name="hexStartAddress">The start address of the specific heap block to be dumped in hexadecimal. (optional)</param>
-            <param name="writeToFile">Bool indicating if output should be written to a file.(optional)</param>
-            <returns>A string containing the bytes read from memory</returns>
-        </member>
-        <member name="M:ERC.DisplayOutput.HeapStats(ERC.HeapInfo,System.UInt64,System.String,System.Boolean)">
-            <summary>
-            Returns statistics about the heap information gathered about the current process.
-            </summary>
-            <param name="hi"></param>
-            <returns>Returns an of strings</returns>
-        </member>
-        <member name="M:ERC.DisplayOutput.ListHeapIDs(ERC.HeapInfo)">
-            <summary>
-            Returns a list of IDs for each heap associated with the current process.
-            </summary>
-            <param name="hi">A HeapInfo object.</param>
-            <returns>Retruns an array of strings containing the heapIds.</returns>
-        </member>
-        <member name="M:ERC.DisplayOutput.SearchHeap(ERC.HeapInfo,System.Byte[],System.UInt64,System.String,System.Boolean)">
-            <summary>
-            Searches the process heap for a specific byte patters. If heapID and hexStartAddress are specified heapID takes precedence. Takes an optional bool indicating if output should be written to file.
-            </summary>
-            <param name="hi">HeapInfo object.</param>
-            <param name="searchBytes">Pattern to be searched for.</param>
-            <param name="heapID">Optional parameter indicating which heap to search.</param>
-            <param name="hexStartAddress">Optional parameter indicating the start address of the heap object to search</param>
-            <param name="writeToFile">Bool indicating if the output should be written to file.</param>
-            <returns>Returns an array of strings.</returns>
+            <returns>A string containing the bytes read from memroy</returns>
         </member>
         <member name="T:ERC.ERCException">
             <summary>
@@ -1780,62 +1664,6 @@
             <param name="Dll">True if the file is a DLL, false if the file is an EXE.</param>
             <param name="readOnly">Boolean for the access mode.</param>
             <returns>If the function succeeds, the return value is TRUE.</returns>
-        </member>
-        <member name="M:ERC.ErcCore.CreateToolhelp32Snapshot(ERC.Structures.SnapshotFlags,System.UInt32)">
-            <summary>
-            Takes a snapshot of the specified processes, as well as the heaps, modules, and threads used by these processes.
-            </summary>
-            <param name="dwFlags">The portions of the system to be included in the snapshot. </param>
-            <param name="th32ProcessID">The process identifier of the process to be included in the snapshot. This parameter can be zero to indicate the current process. This parameter is used when the TH32CS_SNAPHEAPLIST, TH32CS_SNAPMODULE, TH32CS_SNAPMODULE32, or TH32CS_SNAPALL value is specified. Otherwise, it is ignored and all processes are included in the snapshot.</param>
-            <returns>If the function succeeds, it returns an open handle to the specified snapshot.</returns>
-        </member>
-        <member name="M:ERC.ErcCore.Process32First(System.IntPtr,ERC.Structures.PROCESSENTRY32@)">
-            <summary>
-            Retrieves information about the first process encountered in a system snapshot.
-            </summary>
-            <param name="hSnapshot">A handle to the snapshot returned from a previous call to the CreateToolhelp32Snapshot function.</param>
-            <param name="lppe">A pointer to a PROCESSENTRY32 structure.</param>
-            <returns>Returns TRUE if the first entry of the process list has been copied to the buffer or FALSE otherwise. </returns>
-        </member>
-        <member name="M:ERC.ErcCore.Process32Next(System.IntPtr,ERC.Structures.PROCESSENTRY32@)">
-            <summary>
-            Retrieves information about the next process recorded in a system snapshot.
-            </summary>
-            <param name="hSnapshot">A handle to the snapshot returned from a previous call to the CreateToolhelp32Snapshot function.</param>
-            <param name="lppe">A pointer to a PROCESSENTRY32 structure.</param>
-            <returns>Returns TRUE if the next entry of the process list has been copied to the buffer or FALSE otherwise.</returns>
-        </member>
-        <member name="M:ERC.ErcCore.Heap32ListFirst(System.IntPtr,ERC.Structures.HEAPLIST32@)">
-            <summary>
-            Retrieves information about the first heap that has been allocated by a specified process.
-            </summary>
-            <param name="hSnapshot">A handle to the snapshot returned from a previous call to the CreateToolhelp32Snapshot function.</param>
-            <param name="lphl">A pointer to a HEAPLIST32 structure.</param>
-            <returns>Returns TRUE if the first entry of the heap list has been copied to the buffer or FALSE otherwise.</returns>
-        </member>
-        <member name="M:ERC.ErcCore.Heap32ListNext(System.IntPtr,ERC.Structures.HEAPLIST32@)">
-            <summary>
-            Retrieves information about the next heap that has been allocated by a specified process.
-            </summary>
-            <param name="hSnapshot">A handle to the snapshot returned from a previous call to the CreateToolhelp32Snapshot function.</param>
-            <param name="lphl">A pointer to a HEAPLIST32 structure.</param>
-            <returns>Returns TRUE if the first entry of the heap list has been copied to the buffer or FALSE otherwise.</returns>
-        </member>
-        <member name="M:ERC.ErcCore.Heap32First(ERC.Structures.HEAPENTRY32@,System.UInt32,System.IntPtr)">
-            <summary>
-            Retrieves information about the first block of a heap that has been allocated by a process.
-            </summary>
-            <param name="heapentry32">A pointer to a HEAPENTRY32 structure.</param>
-            <param name="processID">The identifier of the process context that owns the heap.</param>
-            <param name="heapID">The identifier of the heap to be enumerated.</param>
-            <returns>Returns TRUE if information for the first heap block has been copied to the buffer or FALSE otherwise. </returns>
-        </member>
-        <member name="M:ERC.ErcCore.Heap32Next(ERC.Structures.HEAPENTRY32@)">
-            <summary>
-            Retrieves information about the next block of a heap that has been allocated by a process.
-            </summary>
-            <param name="heapentry32">A pointer to a HEAPENTRY32 structure.</param>
-            <returns>Returns TRUE if information about the next block in the heap has been copied to the buffer or FALSE otherwise. </returns>
         </member>
         <member name="M:ERC.ErcCore.#ctor">
             <summary>
@@ -4439,67 +4267,6 @@
             ThreadErrorMode
             </summary>
         </member>
-        <member name="T:ERC.Structures.SnapshotFlags">
-            <summary>
-            ToolHelp SnapshotFlags
-            </summary>
-        </member>
-        <member name="T:ERC.Structures.PROCESSENTRY32">
-            <summary>
-            ToolHelp PROCESSENTRY32
-            </summary>
-        </member>
-        <member name="T:ERC.Structures.HEAPLIST32">
-            <summary>
-            Describes one entry (block) of a heap that is being examined.
-            </summary>
-        </member>
-        <member name="T:ERC.Structures.HEAPENTRY32">
-            <summary>
-            Describes one entry (block) of a heap that is being examined.
-            </summary>
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.dwSize">
-            The size of the structure, in bytes *
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.hHandle">
-            A handle to the heap block *
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.dwAddress">
-            The linear address of the start of the block *
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.dwBlockSize">
-            The size of the heap block, in bytes *
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.dwFlags">
-            This member can be one of the following values.
-                            LF32_FIXED    0x00000001
-                           LF32_FREE     0x00000002
-                           LF32_MOVEABLE 0x00000004 *
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.dwLockCount">
-            This member is no longer used and is always set to zero. *
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.dwResvd">
-            Reserved; do not use or alter *
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.th32ProcessID">
-            The identifier of the process that uses the heap *
-        </member>
-        <member name="F:ERC.Structures.HEAPENTRY32.th32HeapID">
-            The heap identifier. This is not a handle, and has meaning only to the tool help functions *
-        </member>
-        <member name="M:ERC.HeapInfo.SearchHeap(System.Byte[],System.UInt64,System.String)">
-            <summary>
-            Searches heap entries for a specified pattern. Returns pointers to all instances of the pattern. If heapID and startAddress are both supplied heapID takes precedence.
-            </summary>
-            <param name="searchBytes">byte array containing the pattern to search for</param>
-            <param name="heapID">ID of the heap to be searched(Optional)</param>
-            <param name="hexStartAddress">Start address of the heap entry to be searched in hexadecimal(Optional)</param>
-            <returns>Returns an ERCResult of IntPtr containing pointers to all instances of the pattern found.</returns>
-        </member>
-        <!-- Badly formed XML comment ignored for member "M:ERC.HeapInfo.HeapStatistics(System.Boolean,System.UInt64,System.String)" -->
-        <!-- Badly formed XML comment ignored for member "M:ERC.HeapInfo.HeapIDs" -->
         <member name="T:ERC.ModuleInfo">
             <summary>
             Contains all information relating to a specific module.
@@ -4702,7 +4469,7 @@
         </member>
         <member name="M:ERC.ProcessInfo.SearchProcessMemory(System.Byte[])">
             <summary>
-            Private function called from Search_Memory. Searches memory regions populated by the process for specific patterns.
+            Private function called from Search_Memory. Searches memory regions populated by the process for specific strings.
             </summary>
             <param name="searchBytes"> Takes a byte array as input to be searched for</param>
             <returns>Returns a list of IntPtr for each instance found.</returns>

--- a/ErcXdbg/RegisteredCommands.cs
+++ b/ErcXdbg/RegisteredCommands.cs
@@ -1381,15 +1381,16 @@ namespace ErcXdbg
 
             /* Race condition: Order of logged items is not guaranteed to be the order presented due to fault in x64dbg. */
             // Dirty thread sleep - ideally wouldn't have to do this.
-            Thread.Sleep(500);
+            //Thread.Sleep(500);
             PLog.WriteLine("Comparing memory region starting at 0x{0} to bytes in file {1}", 
                 address.ToString("X"), path);
-            Thread.Sleep(200);
+            //Thread.Sleep(200);
+            PLog.WriteHtml(String.Join("<br>", output));
             /* There is a maximum length of accepted string on x64dbg side, so let's output line-by-line */
-            foreach (string l in output)
+            /*foreach (string l in output)
             {
                 PLog.WriteLineHtml(l);
-            }
+            }*/
             /* Sleep upon completion so ERC register/unregister messages don't collide with above */
             Thread.Sleep(200);
             return;

--- a/ErcXdbg/RegisteredCommands.cs
+++ b/ErcXdbg/RegisteredCommands.cs
@@ -1379,18 +1379,9 @@ namespace ErcXdbg
             byte[] bytes = File.ReadAllBytes(path);
             string[] output = ERC.DisplayOutput.CompareByteArrayToMemoryRegion(info, address, bytes);
 
-            /* Race condition: Order of logged items is not guaranteed to be the order presented due to fault in x64dbg. */
-            // Dirty thread sleep - ideally wouldn't have to do this.
-            //Thread.Sleep(500);
             PLog.WriteLine("Comparing memory region starting at 0x{0} to bytes in file {1}", 
                 address.ToString("X"), path);
-            //Thread.Sleep(200);
             PLog.WriteHtml(String.Join("<br>", output));
-            /* There is a maximum length of accepted string on x64dbg side, so let's output line-by-line */
-            /*foreach (string l in output)
-            {
-                PLog.WriteLineHtml(l);
-            }*/
             /* Sleep upon completion so ERC register/unregister messages don't collide with above */
             Thread.Sleep(200);
             return;

--- a/ErcXdbgPlugin.sln
+++ b/ErcXdbgPlugin.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.32112.339
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29503.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Managed.x64dbg", "Managed.x64dbg\Managed.x64dbg.csproj", "{3F05E028-6436-4F1C-ABAF-5E7CFBFCB7D7}"
 EndProject
@@ -40,10 +40,10 @@ Global
 		{F2F8BA6A-0112-47CA-9AFA-E8082263AB72}.Release|x86.Build.0 = Release|x86
 		{118C331F-8FC1-4BA6-B5B1-DA397E623CFE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{118C331F-8FC1-4BA6-B5B1-DA397E623CFE}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{118C331F-8FC1-4BA6-B5B1-DA397E623CFE}.Debug|x64.ActiveCfg = Debug|x64
-		{118C331F-8FC1-4BA6-B5B1-DA397E623CFE}.Debug|x64.Build.0 = Debug|x64
-		{118C331F-8FC1-4BA6-B5B1-DA397E623CFE}.Debug|x86.ActiveCfg = Debug|x86
-		{118C331F-8FC1-4BA6-B5B1-DA397E623CFE}.Debug|x86.Build.0 = Debug|x86
+		{118C331F-8FC1-4BA6-B5B1-DA397E623CFE}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{118C331F-8FC1-4BA6-B5B1-DA397E623CFE}.Debug|x64.Build.0 = Debug|Any CPU
+		{118C331F-8FC1-4BA6-B5B1-DA397E623CFE}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{118C331F-8FC1-4BA6-B5B1-DA397E623CFE}.Debug|x86.Build.0 = Debug|Any CPU
 		{118C331F-8FC1-4BA6-B5B1-DA397E623CFE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{118C331F-8FC1-4BA6-B5B1-DA397E623CFE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{118C331F-8FC1-4BA6-B5B1-DA397E623CFE}.Release|x64.ActiveCfg = Release|Any CPU

--- a/Managed.x64dbg/SDK/Bridge.cs
+++ b/Managed.x64dbg/SDK/Bridge.cs
@@ -24,8 +24,8 @@ namespace Managed.x64dbg.SDK
         public const int MAX_MNEMONIC_SIZE = 64;
         public const int PAGE_SIZE = 4096;
 
-        //private const string dll = "x64bridge.dll";   //Uncomment for 64bit
-        private const string dll = "x32bridge.dll"; //Uncomment for 32bit
+        private const string dll = "x64bridge.dll";   //Uncomment for 64bit
+        //private const string dll = "x32bridge.dll"; //Uncomment for 32bit
         private const CallingConvention cdecl = CallingConvention.Cdecl;
 
         [DllImport(dll, CallingConvention = cdecl)]

--- a/Managed.x64dbg/SDK/PLog.cs
+++ b/Managed.x64dbg/SDK/PLog.cs
@@ -18,6 +18,16 @@ namespace Managed.x64dbg.SDK
         {
             Plugins._plugin_logprintf(string.Format(format.Replace("%", "%%"), args));
         }
+        public static void WriteLineHtml(string format, params object[] args)
+        {
+            WriteHtml(string.Format(format.Replace("%", "%%") + "\n", args));
+        }
+
+        public static void WriteHtml(string format, params object[] args)
+        {
+            Plugins._plugin_logprintf_html(string.Format(format.Replace("%", "%%"), args));
+        }
+
     }
 
     public class TextWriterPLog : TextWriter

--- a/Managed.x64dbg/SDK/PLog.cs
+++ b/Managed.x64dbg/SDK/PLog.cs
@@ -20,12 +20,12 @@ namespace Managed.x64dbg.SDK
         }
         public static void WriteLineHtml(string format, params object[] args)
         {
-            WriteHtml(string.Format(format.Replace("%", "%%") + "\n", args));
+            WriteHtml(format + "<br>", args);
         }
 
         public static void WriteHtml(string format, params object[] args)
         {
-            Plugins._plugin_lograw_html(string.Format(format.Replace("%", "%%"), args));
+            Plugins._plugin_lograw_html(string.Format(format, args));
         }
 
     }

--- a/Managed.x64dbg/SDK/PLog.cs
+++ b/Managed.x64dbg/SDK/PLog.cs
@@ -25,7 +25,7 @@ namespace Managed.x64dbg.SDK
 
         public static void WriteHtml(string format, params object[] args)
         {
-            Plugins._plugin_logprintf_html(string.Format(format.Replace("%", "%%"), args));
+            Plugins._plugin_lograw_html(string.Format(format.Replace("%", "%%"), args));
         }
 
     }

--- a/Managed.x64dbg/SDK/Plugins.cs
+++ b/Managed.x64dbg/SDK/Plugins.cs
@@ -27,6 +27,9 @@ namespace Managed.x64dbg.SDK
         public static extern void _plugin_logprintf(string format);
 
         [DllImport(dll, CallingConvention = cdecl)]
+        public static extern void _plugin_logprintf_html(string format);
+
+        [DllImport(dll, CallingConvention = cdecl)]
         public static extern void _plugin_logputs(string text);
 
         [DllImport(dll, CallingConvention = cdecl)]

--- a/Managed.x64dbg/SDK/Plugins.cs
+++ b/Managed.x64dbg/SDK/Plugins.cs
@@ -27,7 +27,7 @@ namespace Managed.x64dbg.SDK
         public static extern void _plugin_logprintf(string format);
 
         [DllImport(dll, CallingConvention = cdecl)]
-        public static extern void _plugin_logprintf_html(string format);
+        public static extern void _plugin_lograw_html(string text);
 
         [DllImport(dll, CallingConvention = cdecl)]
         public static extern void _plugin_logputs(string text);

--- a/Managed.x64dbg/SDK/Plugins.cs
+++ b/Managed.x64dbg/SDK/Plugins.cs
@@ -18,8 +18,8 @@ namespace Managed.x64dbg.SDK
         public delegate void CBPLUGIN(CBTYPE cbType, ref IntPtr callbackInfo);
 
 
-        //private const string dll = "x64dbg.dll";   //Uncomment for 64bit
-        private const string dll = "x32dbg.dll"; //Uncomment for 32bit
+        private const string dll = "x64dbg.dll";   //Uncomment for 64bit
+        // private const string dll = "x32dbg.dll"; //Uncomment for 32bit
 
         private const CallingConvention cdecl = CallingConvention.Cdecl;
 

--- a/Managed.x64dbg/Script/Module.cs
+++ b/Managed.x64dbg/Script/Module.cs
@@ -26,8 +26,8 @@ namespace Managed.x64dbg.Script
             public string name;
         }
 
-        //private const string dll = "x64dbg.dll";   //uncomment for 64bit
-        private const string dll = "x32dbg.dll"; //uncomment for 32bit
+        private const string dll = "x64dbg.dll";   //uncomment for 64bit
+        //private const string dll = "x32dbg.dll"; //uncomment for 32bit
         private const CallingConvention cdecl = CallingConvention.Cdecl;
 
         [DllImport(dll, CallingConvention = cdecl,


### PR DESCRIPTION
Dependent PR: https://github.com/x64dbg/x64dbg/pull/2834

PR submitted to x64dbg main that allows plugin developers to log raw HTML, avoiding the need for a transformer operating on strings searching for coloring string blocks alike previous pr (https://github.com/Andy53/ERC.Xdbg/pull/4).

This required addition of function `Convert.htmlWhitespaceFix` to convert spaces to `&nbsp;` characters to retain their spacing (which was previously being conducted automatically by x64dbg, but cannot if HTML is being submitted intentionally).

There is a couple of short Thread.sleep lines added to `ErcXdbg/RegisteredCommands.cs` Compare function due to logging race conditions with x64dbg. The plugin register/unregister events that are submitted to x64dbg via the bridge upon every command cause competition for the compare function accessing the log.

Attempted to remove calls to `ErcXdbg.cs > PluginStart()` which /seems/ unnecessary however removing causes a crash.

